### PR TITLE
Fix edit-mode toggle on current pi versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed Ctrl+T edit-mode toggling on current pi versions. Thanks to [@johnrichardrinehart](https://github.com/johnrichardrinehart) for PR #2.
+
 ## [0.1.4] - 2026-04-15
 
 - Fixed npm packaging so pi installs the extension source files correctly

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "type": "git",
     "url": "git+https://github.com/nicobailon/pi-side-chat.git"
   },
+  "scripts": {
+    "test": "tsx --test test/*.test.ts"
+  },
   "pi": {
     "extensions": [
       "./index.ts"
@@ -34,5 +37,13 @@
     "@mariozechner/pi-ai": "*",
     "@mariozechner/pi-tui": "*",
     "@sinclair/typebox": "*"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-tui": "*",
+    "@sinclair/typebox": "*",
+    "tsx": "*"
   }
 }

--- a/side-chat-overlay.ts
+++ b/side-chat-overlay.ts
@@ -272,6 +272,15 @@ export class SideChatOverlay implements Component, Focusable {
     return theme.fg(borderColor, "│ ") + truncateToWidth(line, width, "...", true) + theme.fg(borderColor, " │");
   }
 
+  private replaceAgentTools(tools: AgentTool[]): void {
+    const legacyAgent = this.agent as Agent & { setTools?: (tools: AgentTool[]) => void };
+    if (typeof legacyAgent.setTools === "function") {
+      legacyAgent.setTools(tools);
+      return;
+    }
+    this.agent.state.tools = tools;
+  }
+
   handleInput(data: string): void {
     if (matchesKey(data, Key.escape)) {
       if (this.isStreaming) {
@@ -285,12 +294,14 @@ export class SideChatOverlay implements Component, Focusable {
     if (matchesKey(data, Key.alt("r"))) { this.dispose("refork"); return; }
     if (matchesKey(data, Key.alt("n"))) { this.dispose("clear"); return; }
     if (matchesKey(data, Key.ctrl("t"))) {
-      this.toolMode = this.toolMode === "full" ? "read-only" : "full";
+      const nextMode = this.toolMode === "full" ? "read-only" : "full";
       const { forkContext, tracker, onOverlapWarning } = this.options;
-      const builtinTools = this.toolMode === "read-only"
+      const builtinTools = nextMode === "read-only"
         ? createReadOnlyTools(forkContext.cwd)
         : wrapToolsWithOverlapDetection(createCodingTools(forkContext.cwd), tracker, forkContext.cwd, onOverlapWarning);
-      this.agent.setTools([...builtinTools, ...forkContext.extensionTools, this.peekMainTool]);
+
+      this.replaceAgentTools([...builtinTools, ...forkContext.extensionTools, this.peekMainTool]);
+      this.toolMode = nextMode;
       this.options.tui.requestRender();
       return;
     }

--- a/test/side-chat-overlay.test.ts
+++ b/test/side-chat-overlay.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { SideChatOverlay, type ForkContext } from "../side-chat-overlay.ts";
+
+const extensionTool: AgentTool = {
+  name: "extension_tool",
+  label: "extension_tool",
+  description: "Test extension tool",
+  parameters: { type: "object", properties: {} } as AgentTool["parameters"],
+  execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+};
+
+function createOverlay() {
+  let renderRequests = 0;
+  let overlapWarnings = 0;
+  const tui = {
+    terminal: { rows: 40, columns: 120 },
+    requestRender: () => { renderRequests++; },
+  };
+  const theme = {
+    fg: (_color: string, text: string) => text,
+  };
+  const forkContext: ForkContext = {
+    messages: [],
+    model: {
+      id: "test",
+      name: "test",
+      api: "openai-completions",
+      provider: "test",
+      baseUrl: "",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1000,
+      maxTokens: 100,
+    },
+    systemPrompt: "test",
+    thinkingLevel: "off",
+    cwd: "/tmp",
+    extensionTools: [extensionTool],
+  };
+  const overlay = new SideChatOverlay({
+    tui,
+    theme,
+    forkContext,
+    tracker: {
+      writeCount: 0,
+      hasWritten: () => true,
+    },
+    modelRegistry: { getApiKeyForProvider: async () => "test" },
+    sessionManager: {
+      getLeafId: () => null,
+      getEntries: () => [],
+    },
+    shortcut: "alt+/",
+    onOverlapWarning: async () => {
+      overlapWarnings++;
+      return false;
+    },
+    onUnfocus: () => {},
+    onClose: () => {},
+  } as unknown as ConstructorParameters<typeof SideChatOverlay>[0]);
+
+  return {
+    overlay,
+    get renderRequests() { return renderRequests; },
+    get overlapWarnings() { return overlapWarnings; },
+  };
+}
+
+function activeTools(overlay: SideChatOverlay): AgentTool[] {
+  return (overlay as unknown as { agent: { state: { tools: AgentTool[] } } }).agent.state.tools;
+}
+
+function toolNames(overlay: SideChatOverlay): string[] {
+  return activeTools(overlay).map((tool) => tool.name);
+}
+
+function count(names: string[], name: string): number {
+  return names.filter((candidate) => candidate === name).length;
+}
+
+test("Ctrl+T switches tool modes through the current Agent state API", async () => {
+  const state = createOverlay();
+
+  assert.match(state.overlay.render(100).join("\n"), /\[Read-only\]/);
+  assert.deepEqual(toolNames(state.overlay), ["read", "grep", "find", "ls", "extension_tool", "peek_main"]);
+
+  assert.doesNotThrow(() => state.overlay.handleInput("\x14"));
+
+  const editNames = toolNames(state.overlay);
+  assert.match(state.overlay.render(100).join("\n"), /\[Edit\]/);
+  for (const name of ["read", "bash", "edit", "write", "extension_tool", "peek_main"]) {
+    assert.ok(editNames.includes(name), `${name} should be active in edit mode`);
+  }
+  assert.equal(count(editNames, "extension_tool"), 1);
+  assert.equal(count(editNames, "peek_main"), 1);
+
+  const write = activeTools(state.overlay).find((tool) => tool.name === "write");
+  assert.ok(write);
+  const result = await write.execute("test-call", { path: "/tmp/file" }, undefined, undefined);
+  assert.equal(state.overlapWarnings, 1);
+  assert.match(result.content[0]?.type === "text" ? result.content[0].text : "", /Skipped/);
+  assert.equal(state.renderRequests, 1);
+
+  assert.doesNotThrow(() => state.overlay.handleInput("\x14"));
+
+  const readOnlyNames = toolNames(state.overlay);
+  assert.match(state.overlay.render(100).join("\n"), /\[Read-only\]/);
+  assert.deepEqual(readOnlyNames, ["read", "grep", "find", "ls", "extension_tool", "peek_main"]);
+  assert.equal(count(readOnlyNames, "extension_tool"), 1);
+  assert.equal(count(readOnlyNames, "peek_main"), 1);
+  assert.equal(state.renderRequests, 2);
+});
+
+test("Ctrl+T falls back to Agent.setTools on pi-agent-core before 0.65.0", () => {
+  const state = createOverlay();
+  const agent = (state.overlay as unknown as { agent: {
+    state: { tools: AgentTool[] };
+    setTools?: (tools: AgentTool[]) => void;
+  } }).agent;
+  let setToolsCalls = 0;
+  agent.setTools = (tools) => {
+    setToolsCalls++;
+    agent.state.tools = [...tools];
+  };
+
+  assert.doesNotThrow(() => state.overlay.handleInput("\x14"));
+  assert.equal(setToolsCalls, 1);
+  assert.match(state.overlay.render(100).join("\n"), /\[Edit\]/);
+  assert.ok(toolNames(state.overlay).includes("write"));
+
+  assert.doesNotThrow(() => state.overlay.handleInput("\x14"));
+  assert.equal(setToolsCalls, 2);
+  assert.match(state.overlay.render(100).join("\n"), /\[Read-only\]/);
+  assert.deepEqual(toolNames(state.overlay), ["read", "grep", "find", "ls", "extension_tool", "peek_main"]);
+});


### PR DESCRIPTION
Pressing Ctrl+T currently crashes pi because `Agent.setTools()` was removed in pi-agent-core 0.65.0.

```text
TypeError: this.agent.setTools is not a function
    at SideChatOverlay.handleInput (.../pi-side-chat/side-chat-overlay.ts:293:18)
    at TUI.handleInput (.../pi-tui/dist/tui.js:614:35)
```

This changes the toggle to assign `agent.state.tools` on current versions while retaining a narrow `setTools()` fallback for older pi-agent-core releases. The mode label changes only after the next tool list has been built and installed.

The regression test exercises the Ctrl+T input path in both directions and verifies the read-only and edit tool sets, extension tools, `peek_main`, overlap detection, render requests, and mode labels. The suite passes with pi 0.80.10 and the published Mario 0.64.0 package set.