### PR TITLE
Add fullscreen toggle to the side-chat overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed Ctrl+T edit-mode toggling on current pi versions. Thanks to [@johnrichardrinehart](https://github.com/johnrichardrinehart) for PR #2.
+- Added configurable fullscreen toggling for the side-chat overlay. Thanks to [@johnrichardrinehart](https://github.com/johnrichardrinehart) for PR #3.
 
 ## [0.1.4] - 2026-04-15
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Press `Esc` to close it. Reopen with `Alt+/` to continue where you left off.
 
 **Toggle mode** — `Ctrl+T` switches between read-only and edit mode.
 
+**Toggle fullscreen** — `Alt+Shift+F` expands the open side chat to the terminal bounds. Press it again to restore the compact overlay. The conversation, draft, focus, and scroll position remain in place.
+
 **Start fresh** — `Alt+R` re-forks from the latest main context. `Alt+N` starts a blank conversation.
 
 ## Features
@@ -51,13 +53,14 @@ What is the main agent doing right now?
 What changed since I opened this side chat?
 ```
 
-**Non-capturing overlay** — Leave it visible and switch focus back to the main editor. Opens at the top of the screen so the main editor stays visible underneath.
+**Non-capturing overlay** — Leave it visible and switch focus back to the main editor. Compact mode opens at the top of the screen so the main editor stays visible underneath. Fullscreen mode uses the available terminal width and height for long answers and scrollback.
 
 ## Controls
 
 | Key | Action |
 |-----|--------|
 | `Alt+/` | Open side chat / toggle focus |
+| `Alt+Shift+F` | Toggle compact / fullscreen view |
 | `Enter` | Send message |
 | `Esc` | Interrupt streaming, or close when idle |
 | `Alt+R` | Re-fork from latest main context |
@@ -87,13 +90,14 @@ Create a `config.json` next to the extension to change the shortcut:
 
 ```json
 {
-  "shortcut": "alt+/"
+  "shortcut": "alt+/",
+  "fullscreenShortcut": "alt+shift+f"
 }
 ```
 
 ## How It Works
 
-The extension clones the current session context, creates a separate agent instance with all extension-registered tools, and renders it in a TUI overlay. Closing saves the conversation in memory so reopening restores it.
+The extension clones the current session context, creates a separate agent instance with all extension-registered tools, and renders it in a TUI overlay. Compact and fullscreen modes resize that same component and agent in place. Closing saves the conversation in memory so reopening restores it.
 
 Main-agent tool execution events are tracked to maintain a set of written file paths. In edit mode, write-capable tools are wrapped to warn before touching those paths.
 

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { FileActivityTracker } from "./file-activity-tracker.ts";
+import { getOverlayOptions } from "./side-chat-layout.ts";
 import { SideChatOverlay, type ForkContext } from "./side-chat-overlay.ts";
 import { extractWritePaths } from "./tool-wrapper.ts";
 
@@ -33,16 +34,26 @@ function getExtensionAgentTools(): AgentTool[] {
 }
 
 const DEFAULT_SHORTCUT = "alt+/";
+const DEFAULT_FULLSCREEN_SHORTCUT = "alt+shift+f";
 const OVERLAY_BLOCKED_ERROR = "PI_SIDE_CHAT_OVERLAY_BLOCKED";
 
-function loadConfig(): { shortcut: string } {
+function loadConfig(): { shortcut: string; fullscreenShortcut: string } {
   const configPath = join(dirname(fileURLToPath(import.meta.url)), "config.json");
   try {
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
-    return { shortcut: shortcut || DEFAULT_SHORTCUT };
+    const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
+      ? config.fullscreenShortcut.trim()
+      : "";
+    return {
+      shortcut: shortcut || DEFAULT_SHORTCUT,
+      fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
+    };
   } catch {
-    return { shortcut: DEFAULT_SHORTCUT };
+    return {
+      shortcut: DEFAULT_SHORTCUT,
+      fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
+    };
   }
 }
 
@@ -87,6 +98,7 @@ export default function sideChatExtension(pi: ExtensionAPI) {
       cwd: ctx.cwd,
       extensionTools: getExtensionAgentTools(),
     };
+    const overlayOptions = getOverlayOptions("compact");
 
     try {
       const action = await ctx.ui.custom<"close" | "refork" | "clear">(
@@ -106,6 +118,11 @@ export default function sideChatExtension(pi: ExtensionAPI) {
             modelRegistry: ctx.modelRegistry,
             sessionManager: ctx.sessionManager,
             shortcut: config.shortcut,
+            fullscreenShortcut: config.fullscreenShortcut,
+            onDisplayModeChange: (mode) => {
+              // pi-tui retains this object and reads its fields on each render.
+              Object.assign(overlayOptions, getOverlayOptions(mode));
+            },
             onOverlapWarning: (path) => showOverlapWarning(ctx.ui, path),
             onUnfocus: () => overlayHandle?.unfocus(),
             onClose: (action, messages) => {
@@ -119,13 +136,7 @@ export default function sideChatExtension(pi: ExtensionAPI) {
         },
         {
           overlay: true,
-          overlayOptions: {
-            width: "85%",
-            maxHeight: "35%",
-            anchor: "top-center",
-            margin: { top: 1, left: 2, right: 2 },
-            nonCapturing: true,
-          },
+          overlayOptions,
           onHandle: (handle) => {
             overlayHandle = handle;
             handle.focus();
@@ -147,6 +158,11 @@ export default function sideChatExtension(pi: ExtensionAPI) {
   pi.registerShortcut(config.shortcut, {
     description: "Toggle side chat focus (open if closed)",
     handler: toggleSideChat,
+  });
+
+  pi.registerShortcut(config.fullscreenShortcut, {
+    description: "Toggle side chat fullscreen mode",
+    handler: () => activeOverlay?.toggleDisplayMode(),
   });
 
   pi.registerCommand("side", {

--- a/side-chat-layout.ts
+++ b/side-chat-layout.ts
@@ -1,0 +1,39 @@
+import type { OverlayOptions } from "@mariozechner/pi-tui";
+
+export type DisplayMode = "compact" | "fullscreen";
+
+const FIXED_CHROME_LINES = 7;
+const MIN_COMPACT_MESSAGE_LINES = 3;
+
+export function getOverlayOptions(mode: DisplayMode): OverlayOptions {
+  if (mode === "fullscreen") {
+    return {
+      width: "100%",
+      maxHeight: "100%",
+      anchor: "top-left",
+      margin: 0,
+      nonCapturing: true,
+    };
+  }
+
+  return {
+    width: "85%",
+    maxHeight: "35%",
+    anchor: "top-center",
+    margin: { top: 1, left: 2, right: 2 },
+    nonCapturing: true,
+  };
+}
+
+export function getMaxMessageLines(
+  terminalRows: number,
+  mode: DisplayMode,
+  editorLines: number,
+): number {
+  const targetHeight = mode === "fullscreen"
+    ? terminalRows
+    : Math.floor(terminalRows * 0.35);
+
+  const minimum = mode === "fullscreen" ? 0 : MIN_COMPACT_MESSAGE_LINES;
+  return Math.max(minimum, targetHeight - editorLines - FIXED_CHROME_LINES);
+}

--- a/side-chat-overlay.ts
+++ b/side-chat-overlay.ts
@@ -13,6 +13,7 @@ import {
 import { Type } from "@sinclair/typebox";
 import { Editor, Key, matchesKey, truncateToWidth, visibleWidth, type Component, type Focusable, type TUI } from "@mariozechner/pi-tui";
 import type { FileActivityTracker } from "./file-activity-tracker.ts";
+import { getMaxMessageLines, type DisplayMode } from "./side-chat-layout.ts";
 import { SideChatMessages } from "./side-chat-messages.ts";
 import { wrapToolsWithOverlapDetection } from "./tool-wrapper.ts";
 
@@ -33,6 +34,8 @@ interface SideChatOverlayOptions {
   modelRegistry: ModelRegistry;
   sessionManager: SessionManager;
   shortcut: string;
+  fullscreenShortcut: string;
+  onDisplayModeChange: (mode: DisplayMode) => void;
   onOverlapWarning: (path: string) => Promise<boolean>;
   onUnfocus: () => void;
   onClose: (action: "close" | "refork" | "clear", messages: AgentMessage[]) => void;
@@ -58,6 +61,7 @@ export class SideChatOverlay implements Component, Focusable {
   private isStreaming = false;
   private streamingContent = "";
   private toolMode: "full" | "read-only" = "read-only";
+  private displayMode: DisplayMode = "compact";
   private _focused = true;
   private disposed = false;
   private forkLeafId: string | null;
@@ -244,28 +248,41 @@ export class SideChatOverlay implements Component, Focusable {
     lines.push(this.frameLine(`${headerLeft}${headerGap}${status}`, innerWidth, theme, borderColor));
     lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
 
-    const maxLines = Math.max(3, Math.floor(this.options.tui.terminal.rows * 0.35) - 10);
+    const renderedEditorLines = this.editor.render(innerWidth);
+    const editorLines = this.displayMode === "fullscreen"
+      ? renderedEditorLines.slice(0, Math.max(0, this.options.tui.terminal.rows - 7))
+      : renderedEditorLines;
+    const maxLines = getMaxMessageLines(
+      this.options.tui.terminal.rows,
+      this.displayMode,
+      editorLines.length,
+    );
     this.messages.setMaxVisibleLines(maxLines);
-    const msgLines = this.messages.render(innerWidth);
+    const msgLines = maxLines > 0 ? this.messages.render(innerWidth) : [];
     for (const line of msgLines) lines.push(this.frameLine(line, innerWidth, theme, borderColor));
     for (let i = msgLines.length; i < maxLines; i++) lines.push(this.frameLine("", innerWidth, theme, borderColor));
 
     lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
-    for (const line of this.editor.render(innerWidth)) {
+    for (const line of editorLines) {
       lines.push(this.frameLine(line, innerWidth, theme, borderColor));
     }
 
-    const shortcutLabel = this.options.shortcut.replace(/ctrl/i, "Ctrl").replace(/shift/i, "Shift").replace(/alt/i, "Alt");
+    const shortcutLabel = this.formatShortcut(this.options.shortcut);
+    const fullscreenLabel = this.formatShortcut(this.options.fullscreenShortcut);
     const escHint = this.isStreaming ? "Esc stop" : "Esc close";
+    const displayHint = this.displayMode === "fullscreen" ? "restore" : "fullscreen";
     const modeHint = this.toolMode === "read-only" ? "Ctrl+T → edit mode" : "Ctrl+T → read-only";
     const hints = this._focused
-      ? `${escHint} · Enter send · Alt+R refork · Alt+N clear · ${shortcutLabel} → unfocus · ${modeHint}`
-      : `${shortcutLabel} → focus side chat`;
+      ? `${escHint} · Enter send · ${fullscreenLabel} ${displayHint} · Alt+R refork · Alt+N clear · ${shortcutLabel} → unfocus · ${modeHint}`
+      : `${shortcutLabel} → focus side chat · ${fullscreenLabel} ${displayHint}`;
     lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
     lines.push(this.frameLine(theme.fg("dim", hints), innerWidth, theme, borderColor));
     lines.push(theme.fg(borderColor, "└" + "─".repeat(width - 2) + "┘"));
 
-    return lines.map((l) => visibleWidth(l) > width ? truncateToWidth(l, width) : l);
+    const rendered = lines.map((l) => visibleWidth(l) > width ? truncateToWidth(l, width) : l);
+    return this.displayMode === "fullscreen"
+      ? rendered.slice(0, Math.max(0, this.options.tui.terminal.rows))
+      : rendered;
   }
 
   private frameLine(line: string, width: number, theme: Theme, borderColor: string): string {
@@ -281,6 +298,25 @@ export class SideChatOverlay implements Component, Focusable {
     this.agent.state.tools = tools;
   }
 
+  private formatShortcut(shortcut: string): string {
+    return shortcut
+      .split("+")
+      .map((part) => {
+        const lower = part.toLowerCase();
+        if (lower === "ctrl") return "Ctrl";
+        if (lower === "shift") return "Shift";
+        if (lower === "alt") return "Alt";
+        return part.length === 1 ? part.toUpperCase() : part;
+      })
+      .join("+");
+  }
+
+  toggleDisplayMode(): void {
+    this.displayMode = this.displayMode === "compact" ? "fullscreen" : "compact";
+    this.options.onDisplayModeChange(this.displayMode);
+    this.options.tui.requestRender();
+  }
+
   handleInput(data: string): void {
     if (matchesKey(data, Key.escape)) {
       if (this.isStreaming) {
@@ -291,6 +327,7 @@ export class SideChatOverlay implements Component, Focusable {
       return;
     }
     if (matchesKey(data, this.options.shortcut)) { this.options.onUnfocus(); return; }
+    if (matchesKey(data, this.options.fullscreenShortcut)) { this.toggleDisplayMode(); return; }
     if (matchesKey(data, Key.alt("r"))) { this.dispose("refork"); return; }
     if (matchesKey(data, Key.alt("n"))) { this.dispose("clear"); return; }
     if (matchesKey(data, Key.ctrl("t"))) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { OverlayOptions } from "@mariozechner/pi-tui";
+import sideChatExtension from "../index.ts";
+
+test("extension updates the live overlay options object in place", async () => {
+  const commands = new Map<string, { handler: (args: string, context: unknown) => unknown }>();
+  const shortcuts = new Map<string, { handler: (context: unknown) => unknown }>();
+  let focusCalls = 0;
+  let unfocusCalls = 0;
+
+  const pi = {
+    on: () => {},
+    getThinkingLevel: () => "off",
+    registerCommand: (name: string, definition: unknown) => {
+      commands.set(name, definition as { handler: (args: string, context: unknown) => unknown });
+    },
+    registerShortcut: (name: string, definition: unknown) => {
+      shortcuts.set(name, definition as { handler: (context: unknown) => unknown });
+    },
+  };
+
+  sideChatExtension(pi as never);
+
+  const command = commands.get("side");
+  const fullscreenShortcut = shortcuts.get("alt+shift+f");
+  assert.ok(command);
+  assert.ok(fullscreenShortcut);
+
+  const model = {
+    id: "test",
+    name: "test",
+    api: "openai-completions",
+    provider: "test",
+    baseUrl: "",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1000,
+    maxTokens: 100,
+  };
+  const sessionManager = {
+    getEntries: () => [],
+    getLeafId: () => null,
+  };
+  const tui = {
+    terminal: { rows: 40, columns: 120 },
+    hasOverlay: () => false,
+    requestRender: () => {},
+  };
+  const theme = { fg: (_color: string, text: string) => text };
+  const handle = {
+    focus: () => { focusCalls++; },
+    unfocus: () => { unfocusCalls++; },
+    isFocused: () => true,
+  };
+
+  const context = {
+    model,
+    cwd: "/tmp",
+    getSystemPrompt: () => "test",
+    modelRegistry: { getApiKeyForProvider: async () => "test" },
+    sessionManager,
+    ui: {
+      notify: () => {},
+      confirm: async () => true,
+      custom: async (
+        factory: (tui: unknown, theme: unknown, keybindings: unknown, done: (result: string) => void) => {
+          handleInput: (data: string) => void;
+          dispose: () => void;
+        },
+        options: { overlayOptions: OverlayOptions; onHandle: (overlayHandle: unknown) => void },
+      ) => {
+        const originalOptions = options.overlayOptions;
+        let completed = false;
+        const overlay = factory(tui, theme, {}, () => { completed = true; });
+        options.onHandle(handle);
+
+        assert.deepEqual(originalOptions, {
+          width: "85%",
+          maxHeight: "35%",
+          anchor: "top-center",
+          margin: { top: 1, left: 2, right: 2 },
+          nonCapturing: true,
+        });
+
+        overlay.handleInput("\x1b[70;4u");
+        assert.equal(options.overlayOptions, originalOptions);
+        assert.deepEqual(originalOptions, {
+          width: "100%",
+          maxHeight: "100%",
+          anchor: "top-left",
+          margin: 0,
+          nonCapturing: true,
+        });
+
+        fullscreenShortcut.handler(context);
+        assert.equal(options.overlayOptions, originalOptions);
+        assert.deepEqual(originalOptions, {
+          width: "85%",
+          maxHeight: "35%",
+          anchor: "top-center",
+          margin: { top: 1, left: 2, right: 2 },
+          nonCapturing: true,
+        });
+        assert.equal(focusCalls, 1);
+        assert.equal(unfocusCalls, 0);
+
+        overlay.dispose();
+        assert.equal(completed, true);
+        return "close";
+      },
+    },
+  };
+
+  await command.handler("", context);
+});

--- a/test/side-chat-fullscreen.test.ts
+++ b/test/side-chat-fullscreen.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { SideChatOverlay, type ForkContext } from "../side-chat-overlay.ts";
+import type { DisplayMode } from "../side-chat-layout.ts";
+
+function createOverlay(rows = 40) {
+  let renderRequests = 0;
+  const displayChanges: DisplayMode[] = [];
+  const tui = {
+    terminal: { rows, columns: 120 },
+    requestRender: () => { renderRequests++; },
+  };
+  const theme = { fg: (_color: string, text: string) => text };
+  const forkContext: ForkContext = {
+    messages: [],
+    model: {
+      id: "test",
+      name: "test",
+      api: "openai-completions",
+      provider: "test",
+      baseUrl: "",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1000,
+      maxTokens: 100,
+    },
+    systemPrompt: "test",
+    thinkingLevel: "off",
+    cwd: "/tmp",
+    extensionTools: [],
+  };
+  const overlay = new SideChatOverlay({
+    tui,
+    theme,
+    forkContext,
+    tracker: { writeCount: 0, hasWritten: () => false },
+    modelRegistry: { getApiKeyForProvider: async () => "test" },
+    sessionManager: { getLeafId: () => null, getEntries: () => [] },
+    shortcut: "alt+/",
+    fullscreenShortcut: "alt+shift+f",
+    onDisplayModeChange: (mode: DisplayMode) => { displayChanges.push(mode); },
+    onOverlapWarning: async () => true,
+    onUnfocus: () => {},
+    onClose: () => {},
+  } as unknown as ConstructorParameters<typeof SideChatOverlay>[0]);
+
+  return {
+    overlay,
+    tui,
+    displayChanges,
+    get renderRequests() { return renderRequests; },
+  };
+}
+
+function internals(overlay: SideChatOverlay) {
+  return overlay as unknown as {
+    agent: { abort: () => void; state: { tools: AgentTool[] } };
+    editor: {
+      getText: () => string;
+      getCursor: () => { line: number; col: number };
+      setText: (text: string) => void;
+      handleInput: (data: string) => void;
+    };
+    messages: {
+      scrollOffset: number;
+      setMessages: (messages: unknown[]) => void;
+      handleInput: (data: string) => boolean;
+    };
+    isStreaming: boolean;
+  };
+}
+
+test("fullscreen toggle preserves live overlay state and consumes its key", () => {
+  const state = createOverlay();
+  const privateState = internals(state.overlay);
+  const originalAgent = privateState.agent;
+  let aborts = 0;
+  originalAgent.abort = () => { aborts++; };
+
+  privateState.editor.setText("draft text");
+  privateState.editor.handleInput("\x1b[D");
+  privateState.messages.setMessages(Array.from({ length: 30 }, (_, index) => ({
+    role: "user",
+    content: `message ${index}`,
+    timestamp: index,
+  })));
+  state.overlay.render(120);
+  privateState.messages.handleInput("\x1b[5~");
+  privateState.messages.handleInput("\x1b[5~");
+  privateState.isStreaming = true;
+  const cursor = privateState.editor.getCursor();
+
+  state.overlay.handleInput("\x1b[70;4u");
+
+  assert.deepEqual(state.displayChanges, ["fullscreen"]);
+  assert.equal(internals(state.overlay).agent, originalAgent);
+  assert.equal(privateState.editor.getText(), "draft text");
+  assert.deepEqual(privateState.editor.getCursor(), cursor);
+  assert.equal(privateState.messages.scrollOffset, 10);
+  assert.equal(state.overlay.focused, true);
+  assert.equal(aborts, 0);
+  assert.equal(state.renderRequests, 1);
+
+  const fullscreenLines = state.overlay.render(120);
+  assert.equal(fullscreenLines.length, 40);
+  assert.match(fullscreenLines.join("\n"), /Alt\+Shift\+F restore/);
+  assert.ok(fullscreenLines.every((line) => visibleWidth(line) <= 120));
+
+  state.overlay.handleInput("\x1b[70;4u");
+
+  assert.deepEqual(state.displayChanges, ["fullscreen", "compact"]);
+  assert.equal(privateState.editor.getText(), "draft text");
+  assert.deepEqual(privateState.editor.getCursor(), cursor);
+  assert.equal(privateState.messages.scrollOffset, 10);
+  assert.equal(aborts, 0);
+  assert.equal(state.renderRequests, 2);
+
+  const compactLines = state.overlay.render(120);
+  assert.equal(compactLines.length, 14);
+  assert.match(compactLines.join("\n"), /Alt\+Shift\+F fullscreen/);
+  assert.ok(compactLines.every((line) => visibleWidth(line) <= 120));
+});
+
+test("resize recalculates both display modes without exceeding width", () => {
+  const state = createOverlay(24);
+
+  assert.equal(state.overlay.render(80).length, 13);
+  state.overlay.handleInput("\x1b[70;4u");
+  assert.equal(state.overlay.render(80).length, 24);
+
+  state.tui.terminal.rows = 50;
+  assert.equal(state.overlay.render(32).length, 50);
+  assert.ok(state.overlay.render(16).every((line) => visibleWidth(line) <= 16));
+});
+
+test("fullscreen stays within terminal rows with a multiline editor", () => {
+  const state = createOverlay(10);
+  const privateState = internals(state.overlay);
+  privateState.editor.setText("line one\nline two\nline three\nline four");
+
+  state.overlay.handleInput("\x1b[70;4u");
+
+  assert.equal(state.overlay.render(80).length, 10);
+});
+
+test("fullscreen stays within terminals shorter than its fixed chrome", () => {
+  const state = createOverlay(5);
+
+  state.overlay.handleInput("\x1b[70;4u");
+
+  assert.equal(state.overlay.render(80).length, 5);
+});

--- a/test/side-chat-layout.test.ts
+++ b/test/side-chat-layout.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getMaxMessageLines,
+  getOverlayOptions,
+  type DisplayMode,
+} from "../side-chat-layout.ts";
+
+const cases: Array<{ mode: DisplayMode; rows: number; editorLines: number; expected: number }> = [
+  { mode: "compact", rows: 40, editorLines: 1, expected: 6 },
+  { mode: "compact", rows: 40, editorLines: 4, expected: 3 },
+  { mode: "fullscreen", rows: 40, editorLines: 1, expected: 32 },
+  { mode: "fullscreen", rows: 40, editorLines: 4, expected: 29 },
+  { mode: "compact", rows: 10, editorLines: 4, expected: 3 },
+  { mode: "fullscreen", rows: 10, editorLines: 4, expected: 0 },
+];
+
+for (const value of cases) {
+  test(`${value.mode} budget at ${value.rows} rows with ${value.editorLines} editor lines`, () => {
+    assert.equal(getMaxMessageLines(value.rows, value.mode, value.editorLines), value.expected);
+  });
+}
+
+test("display options toggle from compact to fullscreen and back", () => {
+  const compact = getOverlayOptions("compact");
+  const fullscreen = getOverlayOptions("fullscreen");
+
+  assert.deepEqual(compact, {
+    width: "85%",
+    maxHeight: "35%",
+    anchor: "top-center",
+    margin: { top: 1, left: 2, right: 2 },
+    nonCapturing: true,
+  });
+  assert.deepEqual(fullscreen, {
+    width: "100%",
+    maxHeight: "100%",
+    anchor: "top-left",
+    margin: 0,
+    nonCapturing: true,
+  });
+  assert.deepEqual(getOverlayOptions("compact"), compact);
+  assert.notEqual(getOverlayOptions("compact"), compact);
+});

--- a/test/side-chat-messages.test.ts
+++ b/test/side-chat-messages.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SideChatMessages } from "../side-chat-messages.ts";
+
+const theme = { fg: (_color: string, text: string) => text };
+
+test("viewport resize clamps scroll offset without resetting it", () => {
+  const messages = new SideChatMessages(theme as never, 5);
+  messages.setMessages(Array.from({ length: 20 }, (_, index) => ({
+    role: "user" as const,
+    content: `message ${index}`,
+    timestamp: index,
+  })));
+  messages.render(40);
+
+  const state = messages as unknown as { scrollOffset: number };
+  messages.handleInput("\x1b[5~");
+  messages.handleInput("\x1b[5~");
+  assert.equal(state.scrollOffset, 10);
+
+  messages.setMaxVisibleLines(10);
+  assert.equal(state.scrollOffset, 10);
+  messages.setMaxVisibleLines(35);
+  assert.equal(state.scrollOffset, 5);
+  messages.setMaxVisibleLines(5);
+  assert.equal(state.scrollOffset, 5);
+});

--- a/test/side-chat-overlay.test.ts
+++ b/test/side-chat-overlay.test.ts
@@ -54,6 +54,8 @@ function createOverlay() {
       getEntries: () => [],
     },
     shortcut: "alt+/",
+    fullscreenShortcut: "alt+shift+f",
+    onDisplayModeChange: () => {},
     onOverlapWarning: async () => {
       overlapWarnings++;
       return false;


### PR DESCRIPTION
The compact overlay limits long responses and makes scrollback difficult to inspect.

This adds a live `Alt+Shift+F` toggle between the existing compact layout and a fullscreen layout. It resizes the retained overlay and component in place, preserving the active side agent, streaming response, editor contents and cursor, focus, messages, and scroll position. The message viewport now uses the selected display mode and the editor's rendered height instead of a fixed 35% approximation.

`Alt+Shift+F` avoids pi's existing `Alt+F` word-movement binding and can be changed with `fullscreenShortcut` in `config.json`. The footer and README document the control.

The tests cover live overlay-option updates, compact and fullscreen budgets, repeated toggles, editor and agent identity, streaming behavior, scroll clamping, terminal resize, narrow rendering, shortcut consumption, and line-width bounds. All 11 tests pass against pi 0.80.10.

This PR is independent of #2 and does not include the edit-mode API fix.