### PR TITLE
feat: btw aside-session self-cognition — prompt, context & tool harness (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,23 @@
+# pi local state
 .pi/
+.pi-lens.json
+.agents/
+.pi-subagents/
+
+# Local extension config (shortcut overrides, machine-specific)
 config.json
+
+# Local planning notes
 pi-side-chat-plan.md
+
+# Dependencies
+node_modules/
+
+# Logs & debug artifacts
+*.log
+npm-debug.log*
+
+
+# OS cruft
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [Unreleased]
+
+### btw aside-session self-cognition — prompt, context & tool harness (#5)
+
+The btw side chat stays on its own lane: it never continues the main session's work, even when the fork happens while the main agent is mid-tool-call or mid-reasoning.
+
+**Prompt — prompt pack** — all injected prompt text moved out of code into a multi-file prompt pack (`prompts/` directory + `config.json` `promptPack` manifest; per-key md paths relative to the extension dir or absolute; fresh read at every fork; per-key fallback to the bundled default with a notify).
+
+- **framing block** — btw identity + "the cited context is reference only" + focus instruction (template vars `{{cwd}}`/`{{model}}`), injected after the cite as a marked user-role message (never rendered as a chat bubble)
+- **per-turn focus anchor** — "answer only the latest user message in this btw conversation; the cited context's tool calls and answers were performed by the main agent, not you"
+- **lane reminders** — base / escalated / failed-note / preamble (`{{tool}}`/`{{count}}`), injected only in the read-only lane
+
+**Context — shared-prefix layout + fork surgery** — the main lane's system prompt stays in the system slot and the fork snapshot is injected verbatim, so the btw request head is a token prefix of the main request (gateway prefix-cache hits; `cacheRead` ≈ 1/50 of input price).
+
+- fork surgery makes the trailing tool exchange gateway-legal: dangling `tool_calls` get one synthesized `toolResult` each (`[forked mid-execution — the main lane was still running this tool call when the btw side chat opened]`), orphan toolResults are dropped, real landed results are never touched
+- S5 carry-cut: a trailing run of user messages is cut entirely, and the user message that triggered the trailing tool exchange is cut with it — the cite never ends on a user message (reverses the old S4 keep; the 2026-08-13 export showed the model answering the main lane's trailing question instead of the btw message). Shared-prefix caching is unaffected: the btw request stays a token prefix of the main request
+- injected context renders as one collapsed `[Context] N msgs` cite line (UI-only; the LLM context is unchanged)
+
+**Tool harness — lane enforcement** — the read-only lane strips the tool list to builtin read tools + the `config.json` `readOnlyExtensionAllowlist` + `peek_main` (absent tools surface as "not found" — the violation signal).
+
+- `beforeToolCall` hard-blocks out-of-lane tools with the base reminder as the reason; `afterToolCall` re-grounds executed-but-failed read-only calls
+- 1st violation → base reminder; 2nd → escalated wording + turn abort; `🚧 lane blocked` status line
+- edit mode (Ctrl+T) stays untouched
+
+### UI polish
+
+- `Alt+Q` backgrounds the side chat without interrupting its running agent; `Alt+Q` in the main session restores it
+- `PgUp`/`PgDn` scroll the history by a page; `Shift+↑`/`Shift+↓` scroll by a few lines; mouse wheel scrolls over the chat (SGR mouse reporting, consumed so it never leaks into the editor)
+- Scroll-follow freeze: while streaming, the viewport follows the bottom until the user scrolls away, then freezes content-anchored (new streamed lines grow the scroll offset instead of sliding the visible content); following resumes on scroll-to-bottom or a new message
+- Chat area is ~2.5x taller and adapts to small terminals; `[↑N]` scroll indicator in the header; key-hint bar wraps onto a second line on narrow terminals so no hint is clipped
+- New `/btw` command alias for `/side`
+- `Alt+E` exports the btw transcript to `$CWD/.agents/eval/pi-side-chat-<timestamp>.md` as a markdown diagnostic artifact (forked context, framing block, conversation, in-flight stream; git-ignored)
+- Fixed Ctrl+T mode toggle (`agent.state.tools`) and `peek_main` tool-call display for the current pi API
+
+### Dev
+
+- Added MIT `LICENSE` retaining the original author's copyright with modifier attribution
+- Added `tsconfig.json` (mirrors pi's extension-loader module aliases) and `npm run typecheck` so the extension typechecks in-tree
+- Declared `@earendil-works/*` 0.74.0, `typebox` and `typescript` as devDependencies for the dev workspace
+
 ## [0.1.4] - 2026-04-15
 
 - Fixed npm packaging so pi installs the extension source files correctly

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Nico Bailon
+Copyright (c) 2026 yceachan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # pi-side-chat
 
+> Modified fork of [nicobailon/pi-side-chat](https://github.com/nicobailon/pi-side-chat) — original by **Nico Bailon**, modifications by **yceachan**.
+
 **Fork the current conversation into a side chat while the main agent keeps working.**
 
 [![npm version](https://img.shields.io/npm/v/pi-side-chat?style=for-the-badge)](https://www.npmjs.com/package/pi-side-chat)
@@ -13,21 +15,25 @@
 pi install npm:pi-side-chat
 ```
 
-https://github.com/user-attachments/assets/3a359f47-c706-46b9-8b16-d05f430d402c
+<https://github.com/user-attachments/assets/3a359f47-c706-46b9-8b16-d05f430d402c>
 
 You're in the middle of a longer task and want to ask something small without derailing the main thread — check an API detail, sanity-check an approach, search something, or peek at what the main agent is doing. Open the overlay, ask, close it. Main thread never gets interrupted.
 
 ## Quick Start
 
-Open side chat with `Alt+/` or `/side`. Ask a question and press `Enter`.
+Open side chat with `Alt+/`, `/side` or `/btw`. Ask a question and press `Enter`.
 
 Press `Esc` to close it. Reopen with `Alt+/` to continue where you left off.
 
 **Toggle focus** — `Alt+/` switches between the side chat and main editor without closing the overlay.
 
+**Background it** — `Alt+Q` sends the side chat to the background (hidden) without interrupting what it's doing; press `Alt+Q` again in the main session to bring it back. The side agent keeps streaming while hidden.
+
 **Toggle mode** — `Ctrl+T` switches between read-only and edit mode.
 
 **Start fresh** — `Alt+R` re-forks from the latest main context. `Alt+N` starts a blank conversation.
+
+**Export the transcript** — `Alt+E` dumps the btw chat history (forked context, framing block and conversation) to `$CWD/.agents/eval/pi-side-chat-<timestamp>.md` as a markdown diagnostic artifact, useful for debugging feature work.
 
 ## Features
 
@@ -53,24 +59,35 @@ What changed since I opened this side chat?
 
 **Non-capturing overlay** — Leave it visible and switch focus back to the main editor. Opens at the top of the screen so the main editor stays visible underneath.
 
+**Taller chat area** — The message area is ~2.5x taller than before so long answers and tool output stay readable, and it adapts to small terminals (never overflows, always leaves the main editor visible).
+
+**Scroll the history** — `PgUp`/`PgDn` scroll by a page, `Shift+↑`/`Shift+↓` by a few lines, and the mouse wheel scrolls when the pointer is over the chat. A `[↑N]` indicator appears in the header and the hint bar switches to `PgDn/Wheel ↓ latest` whenever you're scrolled away from the latest message.
+
 ## Controls
 
 | Key | Action |
-|-----|--------|
+| ----- | -------- |
 | `Alt+/` | Open side chat / toggle focus |
+| `Alt+Q` | Background the side chat (keeps it running) / restore from main |
 | `Enter` | Send message |
 | `Esc` | Interrupt streaming, or close when idle |
 | `Alt+R` | Re-fork from latest main context |
 | `Alt+N` | Start empty conversation |
+| `Alt+E` | Export the btw chat history to `$CWD/.agents/eval/pi-side-chat-<timestamp>.md` |
 | `Ctrl+T` | Toggle read-only / edit mode |
-| `PgUp` / `Shift+↑` | Scroll up |
-| `PgDn` / `Shift+↓` | Scroll down |
+| `PgUp` / `PgDn` | Scroll history by a page |
+| `Shift+↑` / `Shift+↓` | Scroll by a few lines |
+| Mouse wheel | Scroll when the pointer is over the chat |
 
 ## Command Reference
 
 ### `/side`
 
 Opens the side chat overlay.
+
+### `/btw`
+
+Alias for `/side` — opens the side chat overlay.
 
 ### `peek_main`
 
@@ -93,9 +110,11 @@ Create a `config.json` next to the extension to change the shortcut:
 
 ## How It Works
 
-The extension clones the current session context, creates a separate agent instance with all extension-registered tools, and renders it in a TUI overlay. Closing saves the conversation in memory so reopening restores it.
+The extension clones the current session context, creates a separate agent instance with all extension-registered tools, and renders it in a TUI overlay. Closing saves the conversation in memory so reopening restores it. Backgrounding (`Alt+Q`) hides the overlay via the TUI's overlay handle while the agent keeps running.
 
 Main-agent tool execution events are tracked to maintain a set of written file paths. In edit mode, write-capable tools are wrapped to warn before touching those paths.
+
+While the side chat is open, xterm mouse reporting (SGR) is enabled and wheel events over the overlay are routed to the chat scroll; they are consumed so they never leak into the editor. Mouse reporting is disabled again when the side chat closes.
 
 `peek_main` reads the current session branch on demand and returns a compact summary.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,329 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pi-side-chat",
+      "devDependencies": {
+        "@earendil-works/pi-agent-core": "latest",
+        "@earendil-works/pi-ai": "latest",
+        "@earendil-works/pi-coding-agent": "latest",
+        "@earendil-works/pi-tui": "latest",
+        "typebox": "1.1.38",
+        "typescript": "6.0.3",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-agent-core": "latest",
+        "@earendil-works/pi-ai": "latest",
+        "@earendil-works/pi-coding-agent": "latest",
+        "@earendil-works/pi-tui": "latest",
+        "@sinclair/typebox": "*",
+      },
+    },
+  },
+  "trustedDependencies": [
+    "@google/genai",
+    "protobufjs",
+  ],
+  "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.7", "", { "dependencies": { "@aws-sdk/types": "^3.974.3", "@aws-sdk/xml-builder": "^3.972.38", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.68", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.70", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.13", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/credential-provider-env": "^3.972.68", "@aws-sdk/credential-provider-http": "^3.972.70", "@aws-sdk/credential-provider-login": "^3.972.75", "@aws-sdk/credential-provider-process": "^3.972.68", "@aws-sdk/credential-provider-sso": "^3.973.12", "@aws-sdk/credential-provider-web-identity": "^3.972.74", "@aws-sdk/nested-clients": "^3.997.42", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.75", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/nested-clients": "^3.997.42", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.79", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.68", "@aws-sdk/credential-provider-http": "^3.972.70", "@aws-sdk/credential-provider-ini": "^3.973.13", "@aws-sdk/credential-provider-process": "^3.972.68", "@aws-sdk/credential-provider-sso": "^3.973.12", "@aws-sdk/credential-provider-web-identity": "^3.972.74", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.68", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.12", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/nested-clients": "^3.997.42", "@aws-sdk/token-providers": "3.1108.0", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.74", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/nested-clients": "^3.997.42", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.32", "", { "dependencies": { "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.27", "", { "dependencies": { "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.50", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.42", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/signature-v4-multi-region": "^3.996.44", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.44", "", { "dependencies": { "@aws-sdk/types": "^3.974.3", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.3", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.9", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.38", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.84.1", "", { "dependencies": { "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-telemetry": "^0.84.1", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.84.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@earendil-works/pi-telemetry": "^0.84.1", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ=="],
+
+    "@earendil-works/pi-client": ["@earendil-works/pi-client@0.84.1", "", { "dependencies": { "@earendil-works/pi-protocol": "^0.84.1" } }, "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.84.1", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.84.1", "@earendil-works/pi-ai": "^0.84.1", "@earendil-works/pi-client": "^0.84.1", "@earendil-works/pi-protocol": "^0.84.1", "@earendil-works/pi-tui": "^0.84.1", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "grok-mermaid": "0.2.2", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.9.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A=="],
+
+    "@earendil-works/pi-protocol": ["@earendil-works/pi-protocol@0.84.1", "", { "dependencies": { "typebox": "1.3.7" } }, "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww=="],
+
+    "@earendil-works/pi-telemetry": ["@earendil-works/pi-telemetry@0.84.1", "", {}, "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.84.1", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
+
+    "@smithy/core": ["@smithy/core@3.32.0", "", { "dependencies": { "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.5.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.7.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.7.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q=="],
+
+    "@smithy/types": ["@smithy/types@4.17.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "grok-mermaid": ["grok-mermaid@0.2.2", "", {}, "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@aws-sdk/client-bedrock-runtime/@smithy/node-http-handler": ["@smithy/node-http-handler@4.10.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.10.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1108.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.7", "@aws-sdk/nested-clients": "^3.997.42", "@aws-sdk/types": "^3.974.3", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.10.0", "", { "dependencies": { "@smithy/core": "^3.32.0", "@smithy/types": "^4.17.0", "tslib": "^2.6.2" } }, "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA=="],
+
+    "@earendil-works/pi-agent-core/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "@earendil-works/pi-ai/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "@earendil-works/pi-coding-agent/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "@earendil-works/pi-protocol/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "glob/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+  }
+}

--- a/fork-surgery.ts
+++ b/fork-surgery.ts
@@ -1,0 +1,106 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ToolResultMessage } from "@earendil-works/pi-ai";
+
+/** Approved wording (#12): synthesized result for a tool call that was still
+ *  running on the main lane when the btw side chat forked. */
+export const FORKED_MID_EXECUTION_TEXT =
+  "[forked mid-execution — the main lane was still running this tool call when the btw side chat opened]";
+
+/**
+ * Fork surgery (#12/#16): make the trailing tool exchange gateway-legal on
+ * the fork snapshot, tail-only, never rewriting existing messages.
+ *
+ * The gateway rejects any request with an unanswered `assistant.tool_calls`
+ * (HTTP 400), and the fork snapshot can genuinely end mid-execution (the
+ * main lane was still running the tool when the btw side chat opened). Rules:
+ *
+ * - S1/S2 dangling tool_calls (no matching toolResult in the kept list) get
+ *   one synthesized toolResult each, appended after the trailing exchange.
+ *   Real landed results are never touched.
+ * - Orphan toolResults (no matching tool_call anywhere in the kept list) are
+ *   defensively dropped.
+ * - S5 carry-cut (#16, reverses S4): a trailing run of user messages is cut
+ *   entirely, and the user message that triggered the trailing tool exchange
+ *   is cut with it — the cite never ends on a user message. "The
+ *   newest-looking question in the cite" is the lane-confusion source
+ *   (2026-08-13 export: the model answered the main lane's trailing user
+ *   message instead of the btw message). Tail cuts keep the btw request a
+ *   token prefix of the main request, so shared-prefix caching is unaffected.
+ * - branchSummary/compactionSummary, images and `excludeFromContext` messages
+ *   pass through untouched (shared prefix).
+ *
+ * Matching against the whole kept list (not just the region) keeps valid
+ * answered exchanges intact in pathological orderings; only true orphans and
+ * true dangling calls are touched.
+ */
+export function forkSurgery(messages: AgentMessage[], forkTimestamp = Date.now()): AgentMessage[] {
+  // (1) Locate the trailing exchange region with S5 carry-cut (#16):
+  // - a trailing run of user messages is cut entirely (S4 reversal),
+  // - the user message that triggered the trailing tool exchange is cut with
+  //   it (carryStart), so the cite never ends on a user message.
+  let end = messages.length;
+  while (end > 0 && messages[end - 1].role === "user") end--;
+  let start = end;
+  while (start > 0) {
+    const message = messages[start - 1];
+    if (message.role === "toolResult") {
+      start--;
+      continue;
+    }
+    if (message.role === "assistant" && hasToolCalls(message)) {
+      start--;
+      continue;
+    }
+    break;
+  }
+  const carryStart = start > 0 && messages[start - 1].role === "user" ? start - 1 : start;
+  const region = messages.slice(start, end);
+  const cut = end < messages.length || carryStart < start;
+  if (!cut && region.length === 0) return messages;
+
+  // (2) Index every tool_call in the whole list (id → tool name, for
+  // synthesis) and every toolResult id.
+  const callNames = new Map<string, string>();
+  const resultIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      for (const block of message.content) {
+        if (block.type === "toolCall") callNames.set(block.id, block.name);
+      }
+    } else if (message.role === "toolResult") {
+      resultIds.add(message.toolCallId);
+    }
+  }
+
+  // (3) Orphan toolResults in the region are dropped; everything else in the
+  // region passes through byte-identical.
+  const kept = region.filter((message) => message.role !== "toolResult" || callNames.has(message.toolCallId));
+
+  // (4) Dangling calls in the region get one synthesized toolResult each.
+  const regionCallIds = new Set<string>();
+  for (const message of region) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.content) {
+      if (block.type === "toolCall") regionCallIds.add(block.id);
+    }
+  }
+  const synthesized: ToolResultMessage[] = [];
+  for (const id of regionCallIds) {
+    if (resultIds.has(id)) continue;
+    synthesized.push({
+      role: "toolResult",
+      toolCallId: id,
+      toolName: callNames.get(id) ?? "unknown",
+      content: [{ type: "text", text: FORKED_MID_EXECUTION_TEXT }],
+      isError: false,
+      timestamp: forkTimestamp,
+    });
+  }
+
+  if (!cut && kept.length === region.length && synthesized.length === 0) return messages;
+  return [...messages.slice(0, carryStart), ...kept, ...synthesized];
+}
+
+function hasToolCalls(message: AgentMessage): boolean {
+  return message.role === "assistant" && message.content.some((block) => block.type === "toolCall");
+}

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,13 @@
-import type { AgentMessage, AgentTool } from "@mariozechner/pi-agent-core";
-import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@mariozechner/pi-coding-agent";
-import type { OverlayHandle } from "@mariozechner/pi-tui";
-import { buildSessionContext, ExtensionRunner } from "@mariozechner/pi-coding-agent";
+import type { AgentMessage, AgentTool } from "@earendil-works/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { KeyId, OverlayHandle, Terminal, TUI } from "@earendil-works/pi-tui";
+import { buildSessionContext, ExtensionRunner } from "@earendil-works/pi-coding-agent";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { FileActivityTracker } from "./file-activity-tracker.ts";
-import { SideChatOverlay, type ForkContext } from "./side-chat-overlay.ts";
+import { getExtensionDir, loadPromptPack, type PromptPackManifest } from "./prompt-pack.ts";
+import { SideChatOverlay, SIDE_CHAT_OVERLAY_MARGIN_TOP, SIDE_CHAT_OVERLAY_MAX_HEIGHT, type ForkContext } from "./side-chat-overlay.ts";
+import { disableMouseReporting, enableMouseReporting, parseSgrMouseEvent, WHEEL_DOWN_BUTTON, WHEEL_UP_BUTTON } from "./side-chat-mouse.ts";
 import { extractWritePaths } from "./tool-wrapper.ts";
 
 // Patch to capture the runner instance for extension tool access in side chat.
@@ -33,16 +34,33 @@ function getExtensionAgentTools(): AgentTool[] {
 }
 
 const DEFAULT_SHORTCUT = "alt+/";
+const BACKGROUND_SHORTCUT: KeyId = "alt+q";
 const OVERLAY_BLOCKED_ERROR = "PI_SIDE_CHAT_OVERLAY_BLOCKED";
 
-function loadConfig(): { shortcut: string } {
-  const configPath = join(dirname(fileURLToPath(import.meta.url)), "config.json");
+/** Extension directory: base for config.json and prompt-pack paths. */
+const extensionDir = getExtensionDir();
+
+function loadConfig(): { shortcut: string; readOnlyExtensionAllowlist: string[]; promptPack: PromptPackManifest | undefined } {
+  const configPath = join(extensionDir, "config.json");
   try {
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
     const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
-    return { shortcut: shortcut || DEFAULT_SHORTCUT };
+    // Read-only lane allowlist (#7): extension tools kept in read-only mode.
+    // Absent/empty/invalid ⇒ builtins-only.
+    const raw = config.readOnlyExtensionAllowlist;
+    const readOnlyExtensionAllowlist = Array.isArray(raw)
+      ? raw.filter((n: unknown): n is string => typeof n === "string" && n.length > 0)
+      : [];
+    // Prompt-pack manifest (#13): per-key md paths relative to the extension
+    // dir or absolute; absent keys fall back to the bundled prompts/ defaults.
+    const rawPack = config.promptPack;
+    const promptPack =
+      rawPack && typeof rawPack === "object" && !Array.isArray(rawPack)
+        ? (rawPack as PromptPackManifest)
+        : undefined;
+    return { shortcut: shortcut || DEFAULT_SHORTCUT, readOnlyExtensionAllowlist, promptPack };
   } catch {
-    return { shortcut: DEFAULT_SHORTCUT };
+    return { shortcut: DEFAULT_SHORTCUT, readOnlyExtensionAllowlist: [], promptPack: undefined };
   }
 }
 
@@ -52,6 +70,58 @@ export default function sideChatExtension(pi: ExtensionAPI) {
   let activeOverlay: SideChatOverlay | null = null;
   let overlayHandle: OverlayHandle | null = null;
   let lastMessages: AgentMessage[] | null = null;
+  let mouseTerminal: Terminal | null = null;
+  let removeMouseListener: (() => void) | null = null;
+
+  /**
+   * Enable xterm mouse reporting + SGR while the side chat is open and route
+   * wheel events over the overlay to the chat scroll. Mouse sequences are always
+   * consumed so they never leak into the editor as garbage input.
+   */
+  const installMouseHandler = (tui: TUI) => {
+    if (removeMouseListener) return;
+    enableMouseReporting(tui.terminal);
+    mouseTerminal = tui.terminal;
+    removeMouseListener = tui.addInputListener((data) => {
+      const event = parseSgrMouseEvent(data);
+      if (!event) return undefined;
+      const overlay = activeOverlay;
+      if (overlay && !overlayHandle?.isHidden()) {
+        const viewport = overlay.getViewport();
+        const overOverlay =
+          viewport !== null && event.row >= viewport.topRow && event.row < viewport.topRow + viewport.height;
+        if (overOverlay) {
+          if (event.button === WHEEL_UP_BUTTON) overlay.scrollByLines(3);
+          else if (event.button === WHEEL_DOWN_BUTTON) overlay.scrollByLines(-3);
+        }
+      }
+      return { consume: true };
+    });
+  };
+
+  const uninstallMouseHandler = () => {
+    if (!removeMouseListener) return;
+    removeMouseListener();
+    removeMouseListener = null;
+    if (mouseTerminal) {
+      disableMouseReporting(mouseTerminal);
+      mouseTerminal = null;
+    }
+  };
+
+  /** Background the side chat (hide it) or restore it from the main session. */
+  const backgroundSideChat = async (ctx: ExtensionContext) => {
+    if (!activeOverlay) return openSideChat(ctx);
+    const handle = overlayHandle;
+    if (!handle) return;
+    if (handle.isHidden()) {
+      handle.setHidden(false);
+      handle.focus();
+    } else {
+      handle.unfocus();
+      handle.setHidden(true);
+    }
+  };
 
   pi.on("tool_execution_start", (event, ctx) => {
     if (["write", "edit", "bash"].includes(event.toolName)) {
@@ -62,10 +132,18 @@ export default function sideChatExtension(pi: ExtensionAPI) {
 
   const toggleSideChat = async (ctx: ExtensionContext) => {
     if (activeOverlay) {
-      if (overlayHandle?.isFocused()) {
-        overlayHandle.unfocus();
+      const handle = overlayHandle;
+      if (!handle) return;
+      if (handle.isHidden()) {
+        // Hidden in the background: restore and focus.
+        handle.setHidden(false);
+        handle.focus();
+        return;
+      }
+      if (handle.isFocused()) {
+        handle.unfocus();
       } else {
-        overlayHandle?.focus();
+        handle.focus();
       }
       return;
     }
@@ -79,6 +157,12 @@ export default function sideChatExtension(pi: ExtensionAPI) {
     }
 
     const sessionContext = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
+    // Prompt pack (#13): read fresh at every fork (no cache) so edits to the
+    // manifest files apply on the next fork; per-key fallback + notify.
+    const promptPack = loadPromptPack(config.promptPack, {
+      extensionDir,
+      notify: (message) => ctx.ui.notify(message, "warning"),
+    });
     const forkContext: ForkContext = {
       messages: clear ? [] : (lastMessages ?? sessionContext.messages),
       model: ctx.model,
@@ -105,25 +189,34 @@ export default function sideChatExtension(pi: ExtensionAPI) {
             tracker,
             modelRegistry: ctx.modelRegistry,
             sessionManager: ctx.sessionManager,
-            shortcut: config.shortcut,
+            shortcut: config.shortcut as KeyId,
+            promptPack,
+            readOnlyExtensionAllowlist: config.readOnlyExtensionAllowlist,
             onOverlapWarning: (path) => showOverlapWarning(ctx.ui, path),
             onUnfocus: () => overlayHandle?.unfocus(),
+            onBackground: () => {
+              overlayHandle?.unfocus();
+              overlayHandle?.setHidden(true);
+            },
+            onExport: (path) => ctx.ui.notify(`btw chat exported → ${path}`, "info"),
             onClose: (action, messages) => {
               lastMessages = action === "close" ? messages : null;
               activeOverlay = null;
               overlayHandle = null;
+              uninstallMouseHandler();
               done(action);
             },
           });
+          installMouseHandler(tui);
           return activeOverlay;
         },
         {
           overlay: true,
           overlayOptions: {
             width: "85%",
-            maxHeight: "35%",
+            maxHeight: SIDE_CHAT_OVERLAY_MAX_HEIGHT,
             anchor: "top-center",
-            margin: { top: 1, left: 2, right: 2 },
+            margin: { top: SIDE_CHAT_OVERLAY_MARGIN_TOP, left: 2, right: 2 },
             nonCapturing: true,
           },
           onHandle: (handle) => {
@@ -140,17 +233,28 @@ export default function sideChatExtension(pi: ExtensionAPI) {
       }
       activeOverlay = null;
       overlayHandle = null;
+      uninstallMouseHandler();
       throw error;
     }
   };
 
-  pi.registerShortcut(config.shortcut, {
+  pi.registerShortcut(config.shortcut as KeyId, {
     description: "Toggle side chat focus (open if closed)",
     handler: toggleSideChat,
   });
 
+  pi.registerShortcut(BACKGROUND_SHORTCUT, {
+    description: "Background or restore the side chat (keeps it running)",
+    handler: backgroundSideChat,
+  });
+
   pi.registerCommand("side", {
     description: "Open side chat (fork conversation)",
+    handler: (_, ctx) => toggleSideChat(ctx),
+  });
+
+  pi.registerCommand("btw", {
+    description: "Open side chat (fork conversation) — alias for /side",
     handler: (_, ctx) => toggleSideChat(ctx),
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "pi-side-chat",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pi extension that forks the current conversation into a side chat",
   "type": "module",
   "files": [
     "*.ts",
+    "prompts/",
     "README.md",
     "CHANGELOG.md",
     "banner.png"
@@ -17,6 +18,12 @@
     "coding-agent"
   ],
   "author": "Nico Bailon",
+  "contributors": [
+    {
+      "name": "yceachan",
+      "email": "yceachan@foxmail.com"
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -28,11 +35,27 @@
     ],
     "video": "https://github.com/nicobailon/pi-side-chat/raw/refs/heads/main/side-chat.mp4"
   },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json"
+  },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-agent-core": "*",
-    "@mariozechner/pi-ai": "*",
-    "@mariozechner/pi-tui": "*",
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-agent-core": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-tui": "latest",
     "@sinclair/typebox": "*"
-  }
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "latest",
+    "@earendil-works/pi-ai": "latest",
+    "@earendil-works/pi-coding-agent": "latest",
+    "@earendil-works/pi-tui": "latest",
+    "typebox": "1.1.38",
+    "typescript": "6.0.3"
+  },
+  "trustedDependencies": [
+    "@google/genai",
+    "koffi",
+    "protobufjs"
+  ]
 }

--- a/prompt-pack.ts
+++ b/prompt-pack.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * config.json `promptPack` manifest (#13): each value is a path relative to
+ * the extension dir, or an absolute path. All keys are optional — an absent
+ * or unreadable key falls back to the bundled `prompts/` default.
+ */
+export interface PromptPackManifest {
+  framing?: string;
+  focusAnchor?: string;
+  laneReminders?: {
+    base?: string;
+    escalated?: string;
+    failedNote?: string;
+    preamble?: string;
+  };
+}
+
+/** Fully resolved prompt texts after manifest resolution + file reads. */
+export interface PromptPack {
+  framing: string;
+  focusAnchor: string;
+  laneReminders: {
+    base: string;
+    escalated: string;
+    failedNote: string;
+    preamble: string;
+  };
+}
+
+/** Bundled defaults, shipped git-tracked in `prompts/` (#14 drafts). */
+const BUNDLED_PATHS = {
+  framing: "prompts/btw-framing.md",
+  focusAnchor: "prompts/btw-focus-anchor.md",
+  laneReminders: {
+    base: "prompts/lane-reminder-base.md",
+    escalated: "prompts/lane-reminder-escalated.md",
+    failedNote: "prompts/lane-failed-note.md",
+    preamble: "prompts/lane-preamble.md",
+  },
+} as const;
+
+/** Extension directory (dirname of this module): base for relative paths. */
+export function getExtensionDir(): string {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+/**
+ * Load the prompt pack fresh — no caching, every fork re-reads the manifest
+ * files so edits apply on the next fork. Per-key fallback (#13):
+ *
+ * - configured path missing/unreadable → bundled default + notify warning;
+ * - bundled default unreadable (packaging error) → empty text + notify.
+ */
+export function loadPromptPack(
+  manifest: PromptPackManifest | undefined,
+  options: { extensionDir: string; notify: (message: string) => void },
+): PromptPack {
+  const read = (key: string, configured: string | undefined, bundled: string): string => {
+    if (configured && configured.trim()) {
+      try {
+        return readFileSync(resolvePath(options.extensionDir, configured), "utf-8").trim();
+      } catch {
+        options.notify(`promptPack ${key}: cannot read "${configured}" — falling back to the bundled default`);
+      }
+    }
+    try {
+      return readFileSync(resolvePath(options.extensionDir, bundled), "utf-8").trim();
+    } catch {
+      options.notify(`promptPack ${key}: bundled default "${bundled}" unreadable — using empty prompt text`);
+      return "";
+    }
+  };
+
+  const laneReminders = manifest?.laneReminders ?? {};
+  return {
+    framing: read("framing", manifest?.framing, BUNDLED_PATHS.framing),
+    focusAnchor: read("focusAnchor", manifest?.focusAnchor, BUNDLED_PATHS.focusAnchor),
+    laneReminders: {
+      base: read("laneReminders.base", laneReminders.base, BUNDLED_PATHS.laneReminders.base),
+      escalated: read("laneReminders.escalated", laneReminders.escalated, BUNDLED_PATHS.laneReminders.escalated),
+      failedNote: read("laneReminders.failedNote", laneReminders.failedNote, BUNDLED_PATHS.laneReminders.failedNote),
+      preamble: read("laneReminders.preamble", laneReminders.preamble, BUNDLED_PATHS.laneReminders.preamble),
+    },
+  };
+}
+
+/**
+ * Template substitution (#13): replaces `{{name}}` with the given value.
+ * Undefined variables are left as-is (typos stay visible, never swallowed).
+ * Framing vars: `{{cwd}}` `{{model}}`; lane reminder vars: `{{tool}}` `{{count}}`.
+ */
+export function substituteTemplate(template: string, vars: Record<string, string | number | undefined>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, name: string) => {
+    const value = vars[name];
+    return value === undefined ? match : String(value);
+  });
+}
+
+function resolvePath(extensionDir: string, path: string): string {
+  return isAbsolute(path) ? path : join(extensionDir, path);
+}

--- a/prompts/btw-focus-anchor.md
+++ b/prompts/btw-focus-anchor.md
@@ -1,0 +1,1 @@
+Focus: answer only the latest user message in this btw conversation (the one directly above your reply). The cited main context is reference only — its tool calls and answers were performed by the main agent, not you, and none of its user messages are your questions. Never continue the main lane's pending work, and call tools only when the question actually needs a lookup.

--- a/prompts/btw-framing.md
+++ b/prompts/btw-framing.md
@@ -1,0 +1,8 @@
+You are the btw side chat — a quick-question lane running parallel to the main agent. The main agent is working independently and cannot see this chat.
+
+The main session's context in this conversation is reference only — it is not your work. Do not resume the main agent's pending commands, tool calls, edits, or unfinished answers, and do not redo its work with your own tools.
+
+Your task is the latest user message. Answer it directly and concisely. If the user asks what the main lane is doing, check with `peek_main` or suggest waiting.
+
+Working directory: {{cwd}}
+Model: {{model}}

--- a/prompts/lane-failed-note.md
+++ b/prompts/lane-failed-note.md
@@ -1,0 +1,1 @@
+[btw side chat] That call failed. You are in the read-only lane — retry with read/grep/find/ls, or report back. Do not continue the main lane's work.

--- a/prompts/lane-preamble.md
+++ b/prompts/lane-preamble.md
@@ -1,0 +1,1 @@
+You are in the read-only lane: only read/grep/find/ls, allowlisted tools and peek_main are available here. You cannot write files, edit, or execute commands — that is the main lane's job. If a write is genuinely needed, tell the user to switch to edit mode (Ctrl+T) or ask the main agent.

--- a/prompts/lane-reminder-base.md
+++ b/prompts/lane-reminder-base.md
@@ -1,0 +1,1 @@
+🚧 Lane blocked: `{{tool}}` is not available in this side chat. You are the btw side chat — a quick-question lane parallel to the main agent; the main line is the main agent's job. Answer the latest user message only, with read-only tools (read/grep/find/ls + allowlisted tools). If a write is genuinely needed, tell the user to switch to edit mode (Ctrl+T).

--- a/prompts/lane-reminder-escalated.md
+++ b/prompts/lane-reminder-escalated.md
@@ -1,0 +1,1 @@
+🚧 You have now attempted out-of-lane tools {{count}} times this turn. Stop trying to write or execute. Answer the latest user message with read-only tools, or report back that you cannot.

--- a/side-chat-export.ts
+++ b/side-chat-export.ts
@@ -1,0 +1,245 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isFramingMessage } from "./side-chat-messages.ts";
+
+/**
+ * Alt+E transcript export: dumps the btw session to
+ * `$CWD/.agents/eval/pi-side-chat-<timestamp>.md` as a markdown diagnostic
+ * artifact (feature/debug work). The forked main-lane context and the
+ * framing block are included verbatim, labeled per segment, so the export
+ * shows exactly what the btw session saw in its LLM context.
+ */
+
+export interface ExportSideChatOptions {
+  messages: AgentMessage[];
+  /** Current working directory — the `.agents/eval/` dir is created under it. */
+  cwd: string;
+  modelId: string;
+  toolMode: "full" | "read-only";
+  /** Number of leading messages injected from the main lane (fork context). */
+  forkedMessageCount: number;
+  /** Whether the agent was mid-stream when the export was requested. */
+  streaming: boolean;
+  /** In-flight assistant text at export time (included as a pseudo message). */
+  streamingContent?: string;
+  exportedAt?: Date;
+}
+
+/** Local `YYYY-MM-DD HH:mm:ss` for headers. */
+function formatTimestamp(timestamp: number | Date): string {
+  const d = typeof timestamp === "number" ? new Date(timestamp) : timestamp;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** Local `YYYYMMDD-HHmmss` for the export filename. */
+function formatFileTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
+}
+
+/** Cap a string with an ellipsis note (safety valve for huge payloads). */
+function cap(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}\n… (truncated ${text.length - max} chars)` : text;
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Content block union of the LLM message roles (text/thinking/image/toolCall). */
+type ContentBlock = { type: string } & Record<string, unknown>;
+
+/** Render one content block into markdown lines (text/thinking/image/toolCall). */
+function formatBlock(block: ContentBlock, lines: string[]) {
+  switch (block.type) {
+    case "text":
+      lines.push(String(block.text ?? ""));
+      break;
+    case "thinking":
+      if (typeof block.thinking === "string" && block.thinking) {
+        lines.push("", "_💭 thinking:_", "```text", block.thinking, "```");
+      } else if (block.redacted) {
+        lines.push("_💭 thinking redacted by safety filters_");
+      }
+      break;
+    case "image":
+      lines.push(`_🖼 image (${String(block.mimeType ?? "unknown")}), payload omitted — binary data not exported_`);
+      break;
+    case "toolCall":
+      lines.push(`_🔧 tool call: ${String(block.name ?? "?")}_`);
+      lines.push("```json");
+      lines.push(cap(formatJson(block.arguments), 10_000));
+      lines.push("```");
+      break;
+    default:
+      lines.push(`_content block (${block.type})_`);
+  }
+}
+
+/** Extract the text of a message content (string or blocks) as markdown lines. */
+function formatContent(content: string | ContentBlock[], lines: string[]) {
+  if (typeof content === "string") {
+    lines.push(content);
+    return;
+  }
+  for (const block of content) {
+    formatBlock(block, lines);
+  }
+}
+
+/** Role emoji + display label used in the message heading. */
+function roleLabel(msg: AgentMessage): string {
+  switch (msg.role) {
+    case "user":
+      return "👤 user";
+    case "assistant":
+      return "🤖 assistant";
+    case "toolResult":
+      return `🔧 toolResult: ${String((msg as { toolName?: unknown }).toolName ?? "?")}`;
+    case "branchSummary":
+    case "compactionSummary":
+      return `🗜 ${msg.role}`;
+    case "bashExecution":
+      return "💻 bash";
+    case "custom":
+      return "🧩 custom";
+    default:
+      return `❔ ${String((msg as { role?: unknown }).role ?? "unknown")}`;
+  }
+}
+
+function renderMessage(msg: AgentMessage, index: number, tag: string | null): string[] {
+  const lines: string[] = [];
+  const time = formatTimestamp(msg.timestamp);
+  const tagText = tag ? ` · ${tag}` : "";
+  lines.push(`### [#${index}] ${roleLabel(msg)} · ${time}${tagText}`);
+
+  if (msg.role === "assistant") {
+    const a = msg as AgentMessage & {
+      model?: unknown;
+      stopReason?: unknown;
+      usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+      errorMessage?: unknown;
+    };
+    const meta: string[] = [];
+    if (typeof a.model === "string" && a.model) meta.push(`model ${a.model}`);
+    if (a.stopReason) meta.push(`stop ${String(a.stopReason)}`);
+    const usage = a.usage as { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number } | undefined;
+    if (usage && typeof usage.totalTokens === "number") {
+      meta.push(`tokens ${usage.input ?? 0}/${usage.output ?? 0} (cache ${(usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0)})`);
+    }
+    if (a.errorMessage) meta.push(`error: ${String(a.errorMessage)}`);
+    if (meta.length) lines.push(`_${meta.join(" · ")}_`);
+    if (msg.content.length === 0 && a.errorMessage) {
+      lines.push(String(a.errorMessage));
+    }
+  } else if (msg.role === "toolResult") {
+    const t = msg as AgentMessage & { isError?: unknown; details?: unknown };
+    lines.push(`_status: ${t.isError ? "ERROR" : "OK"}_`);
+    if (t.details !== undefined) {
+      lines.push("_details:_");
+      lines.push("```json");
+      lines.push(cap(formatJson(t.details), 100_000));
+      lines.push("```");
+    }
+  }
+
+  const content = (msg as AgentMessage & { content?: string | ContentBlock[] }).content;
+  if (content !== undefined) {
+    formatContent(content, lines);
+  } else if (msg.role === "bashExecution") {
+    const b = msg as AgentMessage & { command?: unknown };
+    if (b.command !== undefined) lines.push(String(b.command));
+  } else if (msg.role === "branchSummary" || msg.role === "compactionSummary") {
+    const s = msg as AgentMessage & { summary?: unknown; tokensBefore?: unknown };
+    if (s.summary !== undefined) lines.push(String(s.summary));
+    if (s.tokensBefore !== undefined) lines.push(`_tokens before: ${String(s.tokensBefore)}_`);
+  }
+  return lines;
+}
+
+/** Build the full markdown transcript document. */
+export function buildExportMarkdown(opts: ExportSideChatOptions): string {
+  const exportedAt = opts.exportedAt ?? new Date();
+  const messages = opts.messages;
+  const total = messages.length;
+
+  // Segment split: forked main-lane context → framing block → btw conversation.
+  const forked = messages.slice(0, Math.max(0, Math.min(opts.forkedMessageCount, total)));
+  const rest = messages.slice(forked.length);
+  const framingIdx = rest.findIndex(isFramingMessage);
+  const framing = framingIdx >= 0 ? [rest[framingIdx]] : [];
+  const conversation = framingIdx >= 0 ? [...rest.slice(0, framingIdx), ...rest.slice(framingIdx + 1)] : rest;
+
+  const lines: string[] = [];
+  lines.push("# btw Chat Export — pi-side-chat");
+  lines.push("");
+  lines.push("_Exported with `Alt+E` from the btw overlay — diagnostic artifact for feature work._");
+  lines.push("");
+  lines.push(`- exported at: ${formatTimestamp(exportedAt)}`);
+  lines.push(`- model: ${opts.modelId}`);
+  lines.push(`- tool mode: ${opts.toolMode}`);
+  lines.push(`- cwd: \`${opts.cwd}\``);
+  lines.push(
+    `- transcript: ${total} messages (${forked.length} forked context · ${framing.length} framing · ${conversation.length} conversation)`,
+  );
+  lines.push(`- streaming at export: ${opts.streaming ? "yes" : "no"}`);
+
+  const segments: { title: string; msgs: AgentMessage[]; tag: string | null }[] = [];
+  if (forked.length) segments.push({ title: "forked context from main lane", msgs: forked, tag: "forked from main lane" });
+  if (framing.length) segments.push({ title: "framing block", msgs: framing, tag: "framing block" });
+  if (conversation.length) segments.push({ title: "btw conversation", msgs: conversation, tag: null });
+
+  let globalIndex = 0;
+  for (const segment of segments) {
+    lines.push("", "---", "");
+    lines.push(`## ${segment.title} (${segment.msgs.length} message${segment.msgs.length === 1 ? "" : "s"})`);
+    lines.push("");
+    for (const msg of segment.msgs) {
+      globalIndex += 1;
+      lines.push(...renderMessage(msg, globalIndex, segment.tag), "");
+    }
+  }
+
+  // Mid-stream snapshot: append the in-flight assistant text as a pseudo message.
+  if (opts.streaming && opts.streamingContent) {
+    lines.push("---", "");
+    lines.push(`## in-flight assistant response at export time (${opts.streamingContent.length} chars)`);
+    lines.push("");
+    lines.push(`### [#${globalIndex + 1}] 🤖 assistant · ${formatTimestamp(exportedAt)} · streamed, not committed`);
+    lines.push(opts.streamingContent);
+  }
+
+  if (!segments.length && !(opts.streaming && opts.streamingContent)) {
+    lines.push("", "_No messages to export._");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Write the export to `<cwd>/.agents/eval/pi-side-chat-<YYYYMMDD-HHmmss>.md`.
+ * Collisions get a `-2`, `-3`, … suffix. Returns the absolute written path.
+ */
+export function exportChatHistoryToFile(opts: ExportSideChatOptions): string {
+  const exportedAt = opts.exportedAt ?? new Date();
+  const dir = join(opts.cwd, ".agents", "eval");
+  mkdirSync(dir, { recursive: true });
+
+  const base = `pi-side-chat-${formatFileTimestamp(exportedAt)}`;
+  let path = join(dir, `${base}.md`);
+  let counter = 2;
+  while (existsSync(path)) {
+    path = join(dir, `${base}-${counter}.md`);
+    counter += 1;
+  }
+
+  writeFileSync(path, buildExportMarkdown(opts), "utf-8");
+  return path;
+}

--- a/side-chat-messages.ts
+++ b/side-chat-messages.ts
@@ -1,6 +1,21 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { Key, matchesKey, wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
-import type { Theme } from "@mariozechner/pi-coding-agent";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { Key, matchesKey, wrapTextWithAnsi, type Component } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+
+// Marker for the framing block message (#9): it lives in the LLM context
+// (user-role fallback placement) but must never render as a chat bubble.
+const FRAMING_MARKER = Symbol("btw-framing-message");
+
+/** Mark a message as the framing block so the render path skips it. */
+export function markFramingMessage<T extends AgentMessage>(message: T): T {
+  (message as T & { [FRAMING_MARKER]?: boolean })[FRAMING_MARKER] = true;
+  return message;
+}
+
+/** True for framing-block messages (marked at construction). */
+export function isFramingMessage(message: AgentMessage): boolean {
+  return (message as AgentMessage & { [FRAMING_MARKER]?: boolean })[FRAMING_MARKER] === true;
+}
 
 export class SideChatMessages implements Component {
   private messages: AgentMessage[] = [];
@@ -9,12 +24,44 @@ export class SideChatMessages implements Component {
   private toolStatus = "";
   private scrollOffset = 0;
   private totalLines = 0;
+  /**
+   * Number of leading messages injected at open time (fork context, reopened
+   * history, refork). They render as ONE collapsed, non-expandable cite line
+   * instead of full history. UI-only: the messages themselves stay in the
+   * agent's LLM context untouched.
+   */
+  private injectedCount = 0;
+  /**
+   * While the user has scrolled away from the bottom, the content line index
+   * pinned to the viewport bottom. New lines appended below it (streamed
+   * output) grow the scroll offset instead of sliding the visible content.
+   * Null while following the bottom.
+   */
+  private frozenAnchor: number | null = null;
 
   constructor(private theme: Theme, private maxVisibleLines: number) {}
 
+  /**
+   * Mark the first `count` messages as injected context: they render as a
+   * single cite line (e.g. `[Context] 36 msgs`) rather than full history.
+   * Anything appended after the injected batch renders normally. Pass 0
+   * (Alt+N empty start) for no cite. UI-only — LLM context is unaffected.
+   */
+  setInjectedMessageCount(count: number) {
+    this.injectedCount = Math.max(0, count);
+  }
+
   setMessages(messages: AgentMessage[]) {
     this.messages = messages;
-    this.scrollOffset = 0;
+    if (this.frozenAnchor === null) {
+      // Following: snap the viewport to the bottom.
+      this.scrollOffset = 0;
+    } else {
+      // Frozen: keep the anchored content line at the viewport bottom. The
+      // message list only grows, so the anchor stays valid across re-renders
+      // (streaming block -> completed message, tool status coming/going).
+      this.scrollOffset = Math.max(0, this.totalLines - this.frozenAnchor);
+    }
   }
 
   setStreamingContent(content: string) {
@@ -33,14 +80,67 @@ export class SideChatMessages implements Component {
 
   setMaxVisibleLines(max: number) {
     this.maxVisibleLines = Math.max(1, max);
-    this.scrollOffset = Math.min(this.scrollOffset, Math.max(0, this.totalLines - this.maxVisibleLines));
+    if (this.frozenAnchor === null) {
+      this.scrollOffset = Math.min(this.scrollOffset, Math.max(0, this.totalLines - this.maxVisibleLines));
+    } else {
+      this.scrollOffset = Math.max(0, this.totalLines - this.frozenAnchor);
+    }
+  }
+
+  /**
+   * Scroll by a number of lines. Positive = toward older content (like PgUp),
+   * negative = toward the latest message. Clamped to the scrollable range.
+   */
+  scrollBy(lines: number) {
+    if (lines === 0) return false;
+    const maxOffset = Math.max(0, this.totalLines - this.maxVisibleLines);
+    const next = Math.max(0, Math.min(this.scrollOffset + lines, maxOffset));
+    if (next === this.scrollOffset) return false;
+    this.scrollOffset = next;
+    if (next === 0) {
+      // Scrolled back to the bottom: resume following.
+      this.frozenAnchor = null;
+    } else {
+      // Pin the new viewport position so arriving lines don't slide it.
+      this.frozenAnchor = Math.max(0, this.totalLines - next);
+    }
+    return true;
+  }
+
+  /**
+   * Snap to the bottom and resume bottom-following. Called when the user
+   * sends a new message (the conversation restarts from the bottom).
+   */
+  resumeFollowing() {
+    this.frozenAnchor = null;
+    this.scrollOffset = 0;
+  }
+
+  getScrollOffset(): number {
+    return this.scrollOffset;
+  }
+
+  isAtBottom(): boolean {
+    return this.scrollOffset <= 0;
   }
 
   render(width: number): string[] {
     const lines: string[] = [];
+    const injected = Math.min(this.injectedCount, this.messages.length);
 
-    for (const msg of this.messages) {
-      const messageLines = this.renderMessage(msg, width);
+    if (injected > 0) {
+      // One collapsed, non-expandable cite line for the injected batch
+      // (fresh fork context, reopened history, refork) instead of the full
+      // history. The visible conversation starts after it.
+      lines.push(...wrapTextWithAnsi(this.theme.fg("muted", `[Context] ${injected} msg${injected === 1 ? "" : "s"}`), width));
+      lines.push("");
+    }
+
+    for (let i = injected; i < this.messages.length; i++) {
+      // Framing-block messages are part of the LLM context but never render
+      // as chat bubbles (#9 fallback placement).
+      if (isFramingMessage(this.messages[i])) continue;
+      const messageLines = this.renderMessage(this.messages[i], width);
       if (messageLines.length) {
         lines.push(...messageLines, "");
       }
@@ -58,6 +158,12 @@ export class SideChatMessages implements Component {
     }
 
     this.totalLines = lines.length;
+    // Freeze: while the user has scrolled away, grow the offset by the lines
+    // appended at the end, so the anchored content stays put instead of being
+    // pushed up by new streamed output.
+    if (this.frozenAnchor !== null) {
+      this.scrollOffset = Math.max(0, this.totalLines - this.frozenAnchor);
+    }
     const start = Math.max(0, lines.length - this.maxVisibleLines - this.scrollOffset);
     const end = Math.max(0, lines.length - this.scrollOffset);
     return lines.slice(start, end);
@@ -103,13 +209,18 @@ export class SideChatMessages implements Component {
   }
 
   handleInput(data: string): boolean {
-    if (matchesKey(data, Key.pageUp) || matchesKey(data, Key.shift("up"))) {
-      this.scrollOffset = Math.min(this.scrollOffset + 5, Math.max(0, this.totalLines - this.maxVisibleLines));
-      return true;
+    // PgUp / PgDn scroll by a full page; Shift+Up / Shift+Down by a few lines.
+    if (matchesKey(data, Key.pageUp)) {
+      return this.scrollBy(this.maxVisibleLines);
     }
-    if (matchesKey(data, Key.pageDown) || matchesKey(data, Key.shift("down"))) {
-      this.scrollOffset = Math.max(this.scrollOffset - 5, 0);
-      return true;
+    if (matchesKey(data, Key.pageDown)) {
+      return this.scrollBy(-this.maxVisibleLines);
+    }
+    if (matchesKey(data, Key.shift("up"))) {
+      return this.scrollBy(3);
+    }
+    if (matchesKey(data, Key.shift("down"))) {
+      return this.scrollBy(-3);
     }
     return false;
   }

--- a/side-chat-mouse.ts
+++ b/side-chat-mouse.ts
@@ -1,0 +1,52 @@
+import type { Terminal } from "@earendil-works/pi-tui";
+
+/**
+ * Minimal SGR mouse support for the side chat overlay.
+ *
+ * pi-tui has no built-in mouse handling, so the extension enables
+ * xterm mouse reporting (button-event tracking + SGR extended coordinates)
+ * while the side chat is open and consumes the sequences before they
+ * could leak into the editor as garbage input.
+ *
+ * Wheel events arrive as button 64 (scroll up) / 65 (scroll down)
+ * with SGR encoding: ESC [ < B ; Cx ; Cy M (press) / m (release).
+ */
+
+export interface SgrMouseEvent {
+  /** SGR button code (0 = left, 1 = middle, 2 = right, 64 = wheel up, 65 = wheel down, ...) */
+  button: number;
+  /** 1-based column */
+  col: number;
+  /** 1-based row */
+  row: number;
+  isRelease: boolean;
+}
+
+/** Button-event tracking + SGR extended coordinates */
+const MOUSE_ENABLE = "\x1b[?1000h\x1b[?1006h";
+const MOUSE_DISABLE = "\x1b[?1000l\x1b[?1006l";
+
+const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
+
+export const WHEEL_UP_BUTTON = 64;
+export const WHEEL_DOWN_BUTTON = 65;
+
+export function enableMouseReporting(terminal: Terminal): void {
+  terminal.write(MOUSE_ENABLE);
+}
+
+export function disableMouseReporting(terminal: Terminal): void {
+  terminal.write(MOUSE_DISABLE);
+}
+
+/** Parse an SGR mouse sequence (complete, as emitted by StdinBuffer). */
+export function parseSgrMouseEvent(data: string): SgrMouseEvent | null {
+  const match = SGR_MOUSE_RE.exec(data);
+  if (!match) return null;
+  return {
+    button: parseInt(match[1], 10),
+    col: parseInt(match[2], 10),
+    row: parseInt(match[3], 10),
+    isRelease: match[4] === "m",
+  };
+}

--- a/side-chat-overlay.ts
+++ b/side-chat-overlay.ts
@@ -1,5 +1,6 @@
-import { Agent, type AgentEvent, type AgentMessage, type AgentTool, type ThinkingLevel } from "@mariozechner/pi-agent-core";
-import type { Model } from "@mariozechner/pi-ai";
+import { Agent, type AgentEvent, type AgentMessage, type AgentTool, type ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Model } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai/compat";
 import {
   buildSessionContext,
   convertToLlm,
@@ -7,13 +8,17 @@ import {
   createReadOnlyTools,
   getSelectListTheme,
   type ModelRegistry,
-  type SessionManager,
+  type SessionEntry,
   type Theme,
-} from "@mariozechner/pi-coding-agent";
+  type ThemeColor,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { Editor, Key, matchesKey, truncateToWidth, visibleWidth, type Component, type Focusable, type TUI } from "@mariozechner/pi-tui";
+import { Editor, Key, matchesKey, truncateToWidth, visibleWidth, type Component, type Focusable, type KeyId, type TUI } from "@earendil-works/pi-tui";
 import type { FileActivityTracker } from "./file-activity-tracker.ts";
-import { SideChatMessages } from "./side-chat-messages.ts";
+import { forkSurgery } from "./fork-surgery.ts";
+import { exportChatHistoryToFile } from "./side-chat-export.ts";
+import { substituteTemplate, type PromptPack } from "./prompt-pack.ts";
+import { markFramingMessage, SideChatMessages } from "./side-chat-messages.ts";
 import { wrapToolsWithOverlapDetection } from "./tool-wrapper.ts";
 
 export interface ForkContext {
@@ -25,29 +30,60 @@ export interface ForkContext {
   extensionTools: AgentTool[];
 }
 
+/** Minimal session view used by the side chat (getEntries + getLeafId). */
+type SessionView = { getEntries(): SessionEntry[]; getLeafId(): string | null };
+
 interface SideChatOverlayOptions {
   tui: TUI;
   theme: Theme;
   forkContext: ForkContext;
   tracker: FileActivityTracker;
   modelRegistry: ModelRegistry;
-  sessionManager: SessionManager;
-  shortcut: string;
+  sessionManager: SessionView;
+  shortcut: KeyId;
+  /** Prompt texts resolved from config.json `promptPack` (fresh per fork). */
+  promptPack: PromptPack;
+  /** Extension tools allowed in read-only mode (config.json, git-untracked). */
+  readOnlyExtensionAllowlist: string[];
   onOverlapWarning: (path: string) => Promise<boolean>;
   onUnfocus: () => void;
+  onBackground: () => void;
   onClose: (action: "close" | "refork" | "clear", messages: AgentMessage[]) => void;
+  /** Alt+E export written to $CWD/.agents/eval/ — called with the written path. */
+  onExport: (path: string) => void;
 }
 
-const SIDE_CHAT_PROMPT = `
----
-## Side Chat
+/** Overlay max-height used for the side chat (adapted for small terminals at render time). */
+export const SIDE_CHAT_OVERLAY_MAX_HEIGHT = "88%";
+export const SIDE_CHAT_OVERLAY_MARGIN_TOP = 1;
 
-You're in a SIDE CHAT parallel to the main agent. Main is working independently and can't see this.
+/**
+ * Chat area height (message lines): 2.5x the original (~0.35 * rows - 10),
+ * adapted to small terminals so the overlay never overflows the screen and
+ * always leaves a few rows of the main editor visible.
+ */
+export function computeSideChatHeight(rows: number): number {
+  const original = Math.max(3, Math.floor(rows * 0.35) - 10);
+  const desired = Math.round(original * 2.5);
+  // 7 fixed rows (borders, header, editor, hints) around the message area.
+  const overlayCap = Math.max(9, Math.min(Math.floor(rows * 0.88), rows - 4));
+  return Math.max(3, Math.min(desired, overlayCap - 7));
+}
 
-Use \`peek_main\` to see main's activity when user asks about progress or you need context.
-Use \`peek_main({ since_fork: true })\` for activity since side chat opened.
+/**
+ * Shared-prefix layout (#9, reverses decision #6): the main lane's system
+ * prompt stays in the system slot (verbatim, token-identical request head),
+ * and the fork snapshot is injected verbatim below it — main and btw share
+ * the gateway's cached prefix. The btw identity/instruction texts live in
+ * the prompt pack (framing block message + per-turn focus anchor).
+ */
 
-Be concise - this is for quick questions. If user wants something main is doing, suggest waiting.`;
+// --- Lane enforcement (prototype for #8, texts from the prompt pack #13) ---
+// Trigger points only: transformContext (reminder injection) / beforeToolCall
+// (block reason) / afterToolCall (failed-note). UI copy stays in code.
+
+const LANE_BLOCKED_STATUS = "🚧 lane blocked";
+const PRE_ABORT_TEXT = "Turn stopped after repeated out-of-lane attempts.";
 
 const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -64,25 +100,90 @@ export class SideChatOverlay implements Component, Focusable {
   private peekMainTool: AgentTool;
   private spinnerInterval: NodeJS.Timeout | null = null;
   private spinnerFrame = 0;
+  private lastRenderHeight = 0;
+  /** Leading messages injected from the main lane at fork time (context cite). */
+  private forkedMessageCount: number;
+  /** Tool names allowed in the read-only lane (builtins + allowlist + peek_main). */
+  private readOnlyToolNames = new Set<string>();
+  /** Out-of-lane attempts in the current turn (reset on each new user message). */
+  private laneViolations = 0;
+  /** Reminder queued for injection by transformContext before the next LLM call. */
+  private pendingReminder: string | null = null;
+  /** When true, the turn is aborted right after the escalated reminder is injected. */
+  private abortAfterInject = false;
+
+  /**
+   * Chat area height (message lines): 2.5x the original (~0.35 * rows - 10),
+   * adapted to small terminals so the overlay never overflows the screen and
+   * always leaves a few rows of the main editor visible.
+   */
+  private computeChatHeight(): number {
+    return computeSideChatHeight(this.options.tui.terminal.rows);
+  }
+
+  /**
+   * Screen region occupied by the overlay (0-based rows), used to route mouse
+   * wheel events to the chat. Returns null when the overlay is gone.
+   */
+  getViewport(): { topRow: number; height: number } | null {
+    if (this.disposed) return null;
+    const rows = this.options.tui.terminal.rows;
+    const maxHeight = Math.max(
+      1,
+      Math.min(parsePercent(SIDE_CHAT_OVERLAY_MAX_HEIGHT, rows), Math.max(1, rows - SIDE_CHAT_OVERLAY_MARGIN_TOP)),
+    );
+    return {
+      topRow: SIDE_CHAT_OVERLAY_MARGIN_TOP,
+      height: Math.min(this.lastRenderHeight, maxHeight),
+    };
+  }
+
+  /** Scroll the message area (positive = toward older content). Mouse wheel handler. */
+  scrollByLines(lines: number): boolean {
+    const changed = this.messages.scrollBy(lines);
+    if (changed) this.options.tui.requestRender();
+    return changed;
+  }
 
   get focused() { return this._focused; }
   set focused(v: boolean) { this._focused = v; this.editor.focused = v; }
 
   constructor(private options: SideChatOverlayOptions) {
-    const { tui, theme, forkContext, modelRegistry, sessionManager } = options;
-    const forkedMessages = JSON.parse(JSON.stringify(forkContext.messages)) as AgentMessage[];
-    const initialTools = createReadOnlyTools(forkContext.cwd);
+    const { tui, theme, forkContext, modelRegistry, sessionManager, promptPack } = options;
+    // Fork surgery (#12): make the trailing tool exchange gateway-legal on a
+    // clone of the fork snapshot (synthesize missing results, drop orphans).
+    const forkedMessages = forkSurgery(structuredClone(forkContext.messages));
 
     this.forkLeafId = sessionManager.getLeafId();
+    this.forkedMessageCount = forkedMessages.length;
     this.peekMainTool = this.createPeekMainTool(sessionManager);
+    // Strip philosophy (#7): read-only lane = builtins + allowlisted extension
+    // tools + peek_main. Everything else is absent from the list → attempts
+    // surface as "Tool X not found" errors (the detection signal).
+    this.readOnlyToolNames = new Set(this.buildReadOnlyTools().map((t) => t.name));
+
+    // Framing block (#9): between the cite and the user's first btw message.
+    // User-role fallback placement (#11) — the request path keeps only
+    // user/assistant/toolResult roles (convertToLlm + openai-completions
+    // buildRequest), so trailing-system placement is not reachable through
+    // the standard pipeline (ADR-0001 prototype implementation note). The
+    // message is marked so the render path never shows it as a chat bubble.
+    const framingMessage = markFramingMessage({
+      role: "user",
+      content: substituteTemplate(promptPack.framing, { cwd: forkContext.cwd, model: forkContext.model.id }),
+      timestamp: Date.now(),
+    });
 
     this.agent = new Agent({
+      streamFn: streamSimple,
       initialState: {
-        systemPrompt: forkContext.systemPrompt + SIDE_CHAT_PROMPT,
+        // Shared-prefix layout (#9): the MAIN persona stays in the system
+        // slot so the request head matches the main lane token-for-token.
+        systemPrompt: forkContext.systemPrompt,
         model: forkContext.model,
         thinkingLevel: forkContext.thinkingLevel,
-        tools: [...initialTools, ...forkContext.extensionTools, this.peekMainTool],
-        messages: forkedMessages,
+        tools: this.buildReadOnlyTools(),
+        messages: [...forkedMessages, framingMessage],
       },
       convertToLlm,
       getApiKey: async (provider) => {
@@ -90,16 +191,66 @@ export class SideChatOverlay implements Component, Focusable {
         if (!key) throw new Error("No API key available");
         return key;
       },
+      // Transient tail injections (present in the LLM request only, never
+      // stored in the transcript), texts from the prompt pack:
+      // - focus anchor: every turn, both modes (recency position);
+      // - lane preamble: read-only lane only (full mode stays untouched);
+      // - pending lane reminder: after an out-of-lane attempt; escalated
+      //   violations abort the turn right after the reminder is queued.
+      transformContext: async (messages) => {
+        const additions: AgentMessage[] = [
+          { role: "user", content: promptPack.focusAnchor, timestamp: Date.now() },
+        ];
+        if (this.toolMode === "read-only") {
+          additions.push({ role: "user", content: promptPack.laneReminders.preamble, timestamp: Date.now() });
+        }
+        if (this.pendingReminder) {
+          const reminder = this.pendingReminder;
+          this.pendingReminder = null;
+          if (this.abortAfterInject) {
+            this.abortAfterInject = false;
+            this.messages.setErrorContent(PRE_ABORT_TEXT);
+            setTimeout(() => this.agent.abort(), 0);
+          }
+          additions.push({ role: "user", content: reminder, timestamp: Date.now() });
+        }
+        return [...messages, ...additions];
+      },
+      // Belt-and-braces: block any residual present-but-disallowed tool with
+      // the base reminder as the reason (blocked calls never reach afterToolCall).
+      beforeToolCall: async (ctx) => {
+        if (this.toolMode !== "read-only") return undefined;
+        if (this.readOnlyToolNames.has(ctx.toolCall.name)) return undefined;
+        return {
+          block: true,
+          reason: substituteTemplate(promptPack.laneReminders.base, { tool: ctx.toolCall.name }),
+        };
+      },
+      // Layer 2: re-ground executed-but-failed read-only calls (never fires
+      // for blocked/absent tools). Not a violation — no escalation count.
+      afterToolCall: async (ctx) => {
+        if (this.toolMode !== "read-only" || !ctx.isError) return undefined;
+        const content = [...ctx.result.content];
+        if (!content.some((c) => c.type === "text" && c.text.includes("🚧"))) {
+          content.push({ type: "text", text: promptPack.laneReminders.failedNote });
+        }
+        return { content };
+      },
     });
 
     this.agent.subscribe((e) => this.handleAgentEvent(e));
     this.messages = new SideChatMessages(theme, 20);
+    // The whole forked batch (main-session context or reopened history) is
+    // injected at open time: render it as one collapsed cite line, not as
+    // full history. New messages appended after the fork render normally.
+    // The framing block message is marked and skipped by the render path.
+    this.messages.setInjectedMessageCount(forkedMessages.length);
     this.messages.setMessages(forkedMessages);
     this.editor = new Editor(tui, { borderColor: (t) => theme.fg("borderMuted", t), selectList: getSelectListTheme() }, { paddingX: 0 });
     this.editor.onSubmit = (text) => this.handleSubmit(text);
   }
 
-  private createPeekMainTool(sessionManager: SessionManager): AgentTool {
+  private createPeekMainTool(sessionManager: SessionView): AgentTool {
     return {
       name: "peek_main",
       label: "peek_main",
@@ -108,7 +259,8 @@ export class SideChatOverlay implements Component, Focusable {
         lines: Type.Optional(Type.Integer({ description: "Max items (default: 20)", minimum: 1, maximum: 50 })),
         since_fork: Type.Optional(Type.Boolean({ description: "Only show activity after side chat opened" })),
       }),
-      execute: async (_id, args: { lines?: number; since_fork?: boolean }) => {
+      execute: async (_id, params) => {
+        const args = (params ?? {}) as { lines?: number; since_fork?: boolean };
         const entries = sessionManager.getEntries();
         const context = buildSessionContext(entries, sessionManager.getLeafId());
         let msgs = context.messages;
@@ -120,13 +272,56 @@ export class SideChatOverlay implements Component, Focusable {
 
         const recent = msgs.slice(-(args.lines ?? 20));
         if (!recent.length) {
-          return { content: [{ type: "text", text: args.since_fork ? "No new activity since fork." : "No recent activity." }] };
+          return {
+            content: [{ type: "text", text: args.since_fork ? "No new activity since fork." : "No recent activity." }],
+            details: undefined,
+          };
         }
 
         const formatted = recent.map((m) => this.formatMessage(m)).filter(Boolean).join("\n\n");
-        return { content: [{ type: "text", text: `Main agent activity (${recent.length} items):\n\n${formatted}` }] };
+        return {
+          content: [{ type: "text", text: `Main agent activity (${recent.length} items):\n\n${formatted}` }],
+          details: undefined,
+        };
       },
     };
+  }
+
+  /**
+   * Read-only lane tool list (strip philosophy, #7): builtin read tools +
+   * allowlisted extension tools (config.json `readOnlyExtensionAllowlist`,
+   * git-untracked) + peek_main. Everything else is stripped from the list.
+   */
+  private buildReadOnlyTools(): AgentTool[] {
+    const { forkContext } = this.options;
+    const allowlisted = forkContext.extensionTools.filter((t) =>
+      this.options.readOnlyExtensionAllowlist.includes(t.name),
+    );
+    return [...createReadOnlyTools(forkContext.cwd), ...allowlisted, this.peekMainTool];
+  }
+
+  /**
+   * 1st violation → base reminder; 2nd → escalated wording + turn abort.
+   * Texts come from the prompt pack (#13); the reminder is injected by
+   * transformContext before the next LLM call.
+   */
+  private registerLaneViolation(toolName: string) {
+    this.laneViolations += 1;
+    // Stop the spinner first: the lane-blocked status would otherwise be
+    // overwritten by the 80ms spinner tick.
+    this.stopSpinner();
+    if (this.laneViolations === 1) {
+      this.pendingReminder = substituteTemplate(this.options.promptPack.laneReminders.base, { tool: toolName });
+      this.messages.setToolStatus(LANE_BLOCKED_STATUS);
+    } else {
+      this.pendingReminder = substituteTemplate(this.options.promptPack.laneReminders.escalated, {
+        tool: toolName,
+        count: this.laneViolations,
+      });
+      this.abortAfterInject = true;
+      this.messages.setToolStatus(`${LANE_BLOCKED_STATUS} — escalating`);
+    }
+    this.options.tui.requestRender();
   }
 
   private formatMessage(msg: AgentMessage): string {
@@ -137,7 +332,7 @@ export class SideChatOverlay implements Component, Focusable {
     if (msg.role === "assistant") {
       const fullText = msg.content.filter((b) => b.type === "text").map((b) => b.text).join("\n");
       const text = fullText.slice(0, 500);
-      const tools = msg.content.filter((b) => b.type === "tool_call").map((t) => t.toolName);
+      const tools = msg.content.filter((b) => b.type === "toolCall").map((t) => t.name);
       const parts = [text && (text + (fullText.length > 500 ? "..." : "")), tools.length && `[Calling: ${tools.join(", ")}]`].filter(Boolean);
       return parts.length ? `[Assistant]: ${parts.join("\n")}` : "";
     }
@@ -172,9 +367,16 @@ export class SideChatOverlay implements Component, Focusable {
     const trimmed = text.trim();
     if (!trimmed || this.isStreaming || this.disposed) return;
 
+    // New user message: reset the per-turn lane counter.
+    this.laneViolations = 0;
+    this.pendingReminder = null;
+    this.abortAfterInject = false;
+
     this.editor.setText("");
     this.isStreaming = true;
     this.streamingContent = "";
+    // A new user message resumes bottom-following even if the view was frozen.
+    this.messages.resumeFollowing();
     this.messages.setStreamingContent("");
     this.messages.setErrorContent("");
     this.startSpinner();
@@ -213,6 +415,11 @@ export class SideChatOverlay implements Component, Focusable {
       this.messages.setToolStatus(`Running ${event.toolName}...`);
     } else if (event.type === "tool_execution_end") {
       this.startSpinner();
+      // Detection signal: an error result for a tool that is not in the
+      // read-only lane (absent tools produce "Tool X not found" errors).
+      if (this.toolMode === "read-only" && event.isError && !this.readOnlyToolNames.has(event.toolName)) {
+        this.registerLaneViolation(event.toolName);
+      }
     }
 
     this.options.tui.requestRender();
@@ -225,51 +432,49 @@ export class SideChatOverlay implements Component, Focusable {
 
     const { theme, tracker } = this.options;
     const innerWidth = width - 4;
-    const lines: string[] = [];
-    const borderColor = this._focused ? "border" : "borderMuted";
+    const borderColor: ThemeColor = this._focused ? "border" : "borderMuted";
 
     const title = "Side Chat";
     const focusHint = this._focused ? "" : " (unfocused)";
     const mainLabel = tracker.writeCount ? `${tracker.writeCount} file${tracker.writeCount > 1 ? "s" : ""}` : "idle";
     const modeLabel = this.toolMode === "full" ? "Edit" : "Read-only";
-    const modeColor = this.toolMode === "full" ? "warning" : "dim";
-    const status = theme.fg("dim", `[Main: ${mainLabel}] `) + theme.fg(modeColor, `[${modeLabel}]`);
+    const modeColor: ThemeColor = this.toolMode === "full" ? "warning" : "dim";
+    const scrollMark = this.messages.isAtBottom()
+      ? ""
+      : theme.fg("warning", ` [↑${this.messages.getScrollOffset()}]`);
+    const status = theme.fg("dim", `[Main: ${mainLabel}] `) + theme.fg(modeColor, `[${modeLabel}]`) + scrollMark;
     const stream = this.isStreaming ? theme.fg("warning", " ●") : "";
     const left = theme.fg(this._focused ? "accent" : "dim", title) + theme.fg("dim", focusHint) + stream;
-    const leftWidth = Math.max(1, innerWidth - visibleWidth(status) - 1);
-    const headerLeft = truncateToWidth(left, leftWidth);
-    const headerGap = " ".repeat(Math.max(1, innerWidth - visibleWidth(headerLeft) - visibleWidth(status)));
-
-    lines.push(theme.fg(borderColor, "┌" + "─".repeat(width - 2) + "┐"));
-    lines.push(this.frameLine(`${headerLeft}${headerGap}${status}`, innerWidth, theme, borderColor));
-    lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
-
-    const maxLines = Math.max(3, Math.floor(this.options.tui.terminal.rows * 0.35) - 10);
-    this.messages.setMaxVisibleLines(maxLines);
-    const msgLines = this.messages.render(innerWidth);
-    for (const line of msgLines) lines.push(this.frameLine(line, innerWidth, theme, borderColor));
-    for (let i = msgLines.length; i < maxLines; i++) lines.push(this.frameLine("", innerWidth, theme, borderColor));
-
-    lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
-    for (const line of this.editor.render(innerWidth)) {
-      lines.push(this.frameLine(line, innerWidth, theme, borderColor));
-    }
 
     const shortcutLabel = this.options.shortcut.replace(/ctrl/i, "Ctrl").replace(/shift/i, "Shift").replace(/alt/i, "Alt");
     const escHint = this.isStreaming ? "Esc stop" : "Esc close";
-    const modeHint = this.toolMode === "read-only" ? "Ctrl+T → edit mode" : "Ctrl+T → read-only";
-    const hints = this._focused
-      ? `${escHint} · Enter send · Alt+R refork · Alt+N clear · ${shortcutLabel} → unfocus · ${modeHint}`
-      : `${shortcutLabel} → focus side chat`;
-    lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
-    lines.push(this.frameLine(theme.fg("dim", hints), innerWidth, theme, borderColor));
-    lines.push(theme.fg(borderColor, "└" + "─".repeat(width - 2) + "┘"));
+    const modeHint = this.toolMode === "read-only" ? "Ctrl+T edit" : "Ctrl+T readonly";
+    const scrolled = !this.messages.isAtBottom();
+    const scrollHint = scrolled
+      ? theme.fg("warning", `↑${this.messages.getScrollOffset()} · PgDn/Wheel ↓ latest`)
+      : "PgUp/PgDn/Wheel scroll";
+    // Wrap the hint bar onto a second line on narrow terminals so no key hint
+    // gets cut off; one message row is traded for the extra hint row then.
+    const hintLines = this._focused
+      ? buildSideChatHintLines({ innerWidth, scrollHint, escHint, shortcutLabel, modeHint })
+      : [`${scrollHint} · ${shortcutLabel} focus · Alt+Q bg`];
+    const maxLines = Math.max(3, this.computeChatHeight() - (hintLines.length - 1));
+    this.messages.setMaxVisibleLines(maxLines);
+    const msgLines = this.messages.render(innerWidth);
+    for (let i = msgLines.length; i < maxLines; i++) msgLines.push("");
 
-    return lines.map((l) => visibleWidth(l) > width ? truncateToWidth(l, width) : l);
-  }
-
-  private frameLine(line: string, width: number, theme: Theme, borderColor: string): string {
-    return theme.fg(borderColor, "│ ") + truncateToWidth(line, width, "...", true) + theme.fg(borderColor, " │");
+    const lines = renderSideChatFrame({
+      width,
+      theme,
+      borderColor,
+      headerLeft: left,
+      headerRight: status,
+      msgLines,
+      editorLines: this.editor.render(innerWidth),
+      hints: hintLines,
+    });
+    this.lastRenderHeight = lines.length;
+    return lines;
   }
 
   handleInput(data: string): void {
@@ -281,21 +486,50 @@ export class SideChatOverlay implements Component, Focusable {
       }
       return;
     }
+    if (matchesKey(data, Key.alt("q"))) { this.options.onBackground(); return; }
     if (matchesKey(data, this.options.shortcut)) { this.options.onUnfocus(); return; }
     if (matchesKey(data, Key.alt("r"))) { this.dispose("refork"); return; }
     if (matchesKey(data, Key.alt("n"))) { this.dispose("clear"); return; }
+    if (matchesKey(data, Key.alt("e"))) { this.exportChatHistory(); return; }
     if (matchesKey(data, Key.ctrl("t"))) {
       this.toolMode = this.toolMode === "full" ? "read-only" : "full";
+      // Read-only lane keeps the strip philosophy; edit mode stays untouched
+      // (enforcement out of scope until the crash bug is understood, #4).
       const { forkContext, tracker, onOverlapWarning } = this.options;
-      const builtinTools = this.toolMode === "read-only"
-        ? createReadOnlyTools(forkContext.cwd)
-        : wrapToolsWithOverlapDetection(createCodingTools(forkContext.cwd), tracker, forkContext.cwd, onOverlapWarning);
-      this.agent.setTools([...builtinTools, ...forkContext.extensionTools, this.peekMainTool]);
+      this.agent.state.tools = this.toolMode === "read-only"
+        ? this.buildReadOnlyTools()
+        : [...wrapToolsWithOverlapDetection(createCodingTools(forkContext.cwd), tracker, forkContext.cwd, onOverlapWarning), ...forkContext.extensionTools, this.peekMainTool];
       this.options.tui.requestRender();
       return;
     }
     if (this.messages.handleInput(data)) { this.options.tui.requestRender(); return; }
     this.editor.handleInput(data);
+    this.options.tui.requestRender();
+  }
+
+  /**
+   * Alt+E: export the btw transcript to `$CWD/.agents/eval/pi-side-chat-<ts>.md`
+   * as a markdown diagnostic artifact (feature/debug work). The snapshot is
+   * taken from the agent state at the moment of the keypress.
+   */
+  private exportChatHistory() {
+    try {
+      const path = exportChatHistoryToFile({
+        messages: [...this.agent.state.messages],
+        streamingContent: this.streamingContent,
+        cwd: this.options.forkContext.cwd,
+        modelId: this.options.forkContext.model.id,
+        toolMode: this.toolMode,
+        forkedMessageCount: this.forkedMessageCount,
+        streaming: this.isStreaming,
+      });
+      // Status line feedback inside the overlay + a toast in the main session.
+      this.stopSpinner();
+      this.messages.setToolStatus(`✓ exported → ${path}`);
+      this.options.onExport(path);
+    } catch (error) {
+      this.messages.setErrorContent(`Export failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
     this.options.tui.requestRender();
   }
 
@@ -312,4 +546,71 @@ export class SideChatOverlay implements Component, Focusable {
     this.messages.invalidate();
     this.editor.invalidate();
   }
+}
+
+function parsePercent(value: string, reference: number): number {
+  const match = /^(\d+(?:\.\d+)?)%$/.exec(value);
+  if (!match) return reference;
+  return Math.floor((reference * parseFloat(match[1])) / 100);
+}
+
+/**
+ * Pure side chat frame renderer: borders, header, messages, editor, hints.
+ * Kept separate so previews/tests can render the exact same frame without a TUI.
+ */
+export interface SideChatFrameOptions {
+  width: number;
+  theme: Theme;
+  borderColor: ThemeColor;
+  headerLeft: string;
+  headerRight: string;
+  msgLines: string[];
+  editorLines: string[];
+  hints: string[];
+}
+
+export function renderSideChatFrame(opts: SideChatFrameOptions): string[] {
+  const { theme, width, borderColor } = opts;
+  const innerWidth = width - 4;
+  const lines: string[] = [];
+
+  const headerLeftWidth = Math.max(1, innerWidth - visibleWidth(opts.headerRight) - 1);
+  const headerLeft = truncateToWidth(opts.headerLeft, headerLeftWidth);
+  const headerGap = " ".repeat(Math.max(1, innerWidth - visibleWidth(headerLeft) - visibleWidth(opts.headerRight)));
+
+  lines.push(theme.fg(borderColor, "┌" + "─".repeat(width - 2) + "┐"));
+  lines.push(frameLine(theme, borderColor, `${headerLeft}${headerGap}${opts.headerRight}`, innerWidth));
+  lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
+  for (const line of opts.msgLines) lines.push(frameLine(theme, borderColor, line, innerWidth));
+  lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
+  for (const line of opts.editorLines) lines.push(frameLine(theme, borderColor, line, innerWidth));
+  lines.push(theme.fg(borderColor, "├" + "─".repeat(width - 2) + "┤"));
+  for (const line of opts.hints) lines.push(frameLine(theme, borderColor, theme.fg("dim", line), innerWidth));
+  lines.push(theme.fg(borderColor, "└" + "─".repeat(width - 2) + "┘"));
+
+  return lines.map((l) => (visibleWidth(l) > width ? truncateToWidth(l, width) : l));
+}
+
+function frameLine(theme: Theme, borderColor: ThemeColor, line: string, width: number): string {
+  return theme.fg(borderColor, "│ ") + truncateToWidth(line, width, "...", true) + theme.fg(borderColor, " │");
+}
+
+/**
+ * Build the key-hint bar for the focused overlay. Fits everything on one line
+ * when possible, otherwise splits into two lines (scroll hints stay first).
+ */
+export function buildSideChatHintLines(options: {
+  innerWidth: number;
+  scrollHint: string;
+  escHint: string;
+  shortcutLabel: string;
+  modeHint: string;
+}): string[] {
+  const { innerWidth, scrollHint, escHint, shortcutLabel, modeHint } = options;
+  const primary = `${scrollHint} · ${escHint} · Enter send`;
+  const secondary = `Alt+R fork · Alt+N new · Alt+E export · ${shortcutLabel} main · ${modeHint} · Alt+Q bg`;
+  if (visibleWidth(`${primary} · ${secondary}`) <= innerWidth) {
+    return [`${primary} · ${secondary}`];
+  }
+  return [primary, secondary];
 }

--- a/tool-wrapper.ts
+++ b/tool-wrapper.ts
@@ -1,4 +1,4 @@
-import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { FileActivityTracker } from "./file-activity-tracker.ts";
 
 export function wrapToolsWithOverlapDetection(
@@ -30,6 +30,7 @@ function wrapTool(
           if (!proceed) {
             return {
               content: [{ type: "text", text: `Skipped: ${path} (main agent has modified it)` }],
+              details: undefined,
             };
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "@mariozechner/pi-agent-core": ["./node_modules/@earendil-works/pi-agent-core/dist/index.d.ts"],
+      "@mariozechner/pi-ai": ["./node_modules/@earendil-works/pi-ai/dist/index.d.ts"],
+      "@mariozechner/pi-ai/compat": ["./node_modules/@earendil-works/pi-ai/dist/compat.d.ts"],
+      "@mariozechner/pi-ai/oauth": ["./node_modules/@earendil-works/pi-ai/dist/oauth.d.ts"],
+      "@mariozechner/pi-ai/providers/all": ["./node_modules/@earendil-works/pi-ai/dist/providers/all.d.ts"],
+      "@mariozechner/pi-coding-agent": ["./node_modules/@earendil-works/pi-coding-agent/dist/index.d.ts"],
+      "@mariozechner/pi-tui": ["./node_modules/@earendil-works/pi-tui/dist/index.d.ts"],
+      "@sinclair/typebox": ["./node_modules/typebox/build/index.d.mts"],
+      "@sinclair/typebox/compile": ["./node_modules/typebox/build/compile/index.d.mts"],
+      "@sinclair/typebox/value": ["./node_modules/typebox/build/value/index.d.mts"]
+    }
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
Closes #5 — Here is my design PR to let the btw side chat stays on its own lane: it works well in my personal experience. 

> [!note]
>
> I design the self-aside-Cognition harness through prompt,context,and tool call limits thee  dimensions .What 's more ,I also do some job to polish the UI.

Branch: `feat/issue-5-aside-Cognition` 

# Harness Design

## Context — shared-prefix layout + fork surgery (design)

> [!note]
>
> for a better prefix cached , I decited to leaves all main lane 's context in the btw lane,so that llm could work cheaper,with enough main lane context as ref.
>
> However,in main lane context ,the user tail messages ,and the doing job,which has  a High weight, and leads agent a strong willing to complete it.
>
> Since that ,I just cut off the tail messages , form here fork a aside session , still share the KV cache , but ever no too much main lane noisy. 



### 1.1 Shared-prefix layout — byte-level constraint for KV-cache economics

Goal: the btw request head is **token-identical** to the main lane's request,
so the gateway's (OpenAI-compatible) prefix cache hits. Economics: per
CHANGELOG, `cacheRead ≈ 1/50` of input price, and the fork snapshot (system
prompt + full history up to the fork point) is the most expensive part of the
request.

Two hard constraints derived from that goal:

- **Main persona stays in the system slot, verbatim** (decision #9, explicitly
  reversing #6). Any injection of btw identity into the system prompt breaks
  head byte-identity and forfeits the cache hit.
- **Fork snapshot injected verbatim** into `initialState.messages`.
  `branchSummary`/`compactionSummary`, images, and `excludeFromContext`
  messages pass through untouched.

Pipeline fact that constrains placement: `convertToLlm` + the
openai-completions `buildRequest` path keeps **only user/assistant/toolResult
roles**. Trailing-system placement of the framing block is therefore
unreachable — hence the user-role fallback in 1.3.

### 1.2 Fork surgery (`fork-surgery.ts`)

 A pure function that makes the fork snapshot gateway-legal and recency-safe, without touching anything before the tail.

 Problem 1 — gateway legality. OpenAI-style endpoints return HTTP 400 if the request contains unanswered assistant.tool_calls. When you fork while the main lane is
 mid-tool-execution, the snapshot ends on exactly that. Fix: every dangling call id gets one synthesized toolResult ("[forked mid-execution…]", isError: false). Truly orphaned
 toolResults (no call anywhere in the list) are dropped. Real landed results are never rewritten.

 Problem 2 — recency poisoning (S5 carry-cut). Even a legal sequence is toxic if the cite ends on the main lane's trailing user question — the model answers that instead of your
 btw question. Fix: cut the trailing run of user messages, plus the user message that triggered the trailing tool exchange, so the cite never ends on a user message.

### 1.3 Framing block placement (`side-chat-overlay.ts`, `prompts/btw-framing.md`)

The btw identity text ("you are a quick-question lane parallel to the main
agent; the cited context is reference only") has three candidate slots:

- system slot — forbidden (breaks prefix identity),
- trailing system message — stripped by `buildRequest`,
- **user-role fallback**: a synthetic user message inserted between the cite
  and the first btw user message, marked with a `Symbol`
  (`markFramingMessage`) so the render path skips it. Present in the LLM
  context, never rendered as a chat bubble.

Template vars `{{cwd}}` / `{{model}}` substituted at construction.

### 1.4 Per-turn focus anchor — staking the attention peak

Rather than removing context without bound (impossible), the design injects,
via the `transformContext` hook before **every** LLM call, a focus anchor at
the **recency position** — the immediate prefix of the next completion, where
attention peaks:

> answer only the latest user message in this btw conversation; the cited
> context's tool calls and answers were performed by the main agent, not you.

Key properties:

- **Transient** — present in the request only, never written back to
  `state.messages`; the transcript stays clean.
- **Both modes** — injected every turn in read-only and edit mode.
- The lane preamble and violation reminders ride the same transformContext
  channel (section 3).



## Prompt — prompt pack (design)

> [!note]
>
> As I mentions, the main lane context lay on the top  of request for a better KV cached,then here is the aside prompt design.

All injected prompt text moved out of code into a multi-file prompt pack: `prompts/` (git-tracked) + a `config.json` `promptPack` manifest. Per-key md paths (relative to the extension dir or absolute), per-key fallback to the bundled default with a notify, and a fresh read at **every fork** — prompt edits apply on the next fork without reloading the extension.

- **framing block** (`btw-framing.md`) — btw identity ("quick-question lane parallel to the main agent"), the citation rule ("the main session's context is reference only — not your work; do not resume the main agent's pending commands, tool calls, edits, or unfinished answers"), and the focus instruction ("your task is the latest user message"). Template vars `{{cwd}}`/`{{model}}`.
- **per-turn focus anchor** (`btw-focus-anchor.md`) — injected at the recency position every turn, both modes: "answer only the latest user message in this btw conversation; the cited context's tool calls and answers were performed by the main agent, not you".
- **lane reminders** (`lane-reminder-base/escalated/failed-note/preamble`) — `{{tool}}`/`{{count}}` templated, injected only in the read-only lane.

**Effect** — the identity/focus texts are no longer hard-coded in TS; users can restyle or strengthen them via `config.json` (hot-reloaded per fork), and the repo ships the exact approved drafts as reviewable assets.



## Tool harness — lane enforcement (design)

> [!note]
>
> Whenever Agent trys to call any w/x tools , a tool call fail messages is too cheap to drag agent back,so I design this prompt inject mechanism.

Read-only lane with the **strip philosophy**: the tool list is stripped to builtin read tools (`read`/`grep`/`find`/`ls`) + the `config.json` `readOnlyExtensionAllowlist` (extension tools like `web_search`, `fetch_content`, …) + `peek_main`. Absent tools surface as "Tool X not found" — the violation detection signal. Enforcement hooks live on the side-chat `Agent` (pi-level hooks never reach it):

- `beforeToolCall` — hard-blocks any residual present-but-disallowed tool, with the base reminder as the model-visible reason.
- `afterToolCall` — re-grounds executed-but-failed read-only calls with the failed-note (never counts as a violation).
- Escalation — 1st violation → base reminder; 2nd → escalated wording + **turn abort**; `🚧 lane blocked` status line in the overlay.
- [issue] Edit mode (`Ctrl+T`) is untouched.

# UI polish

- `Alt+Q` backgrounds the side chat **without interrupting its running agent**; `Alt+Q` in the main session restores it
- Scroll: `PgUp`/`PgDn` by a page, `Shift+↑`/`Shift+↓` by a few lines, mouse wheel over the chat (xterm SGR mouse reporting, consumed so it never leaks into the editor)
- Scroll-follow freeze: while streaming, the viewport follows the bottom until the user scrolls away, then freezes content-anchored (new streamed lines grow the scroll offset instead of sliding the visible content); following resumes on scroll-to-bottom or a new message
- Injected context renders as **one collapsed `[Context] N msgs` cite line** instead of full history (UI-only; the LLM context is unchanged)
- Chat area ~2.5× taller, adapts to small terminals; `[↑N]` scroll indicator in the header; key-hint bar wraps onto a second line on narrow terminals
- New `/btw` command alias for `/side`
- `Alt+E` exports the btw transcript to `$CWD/.agents/eval/pi-side-chat-<timestamp>.md` as a markdown diagnostic artifact (git-ignored)
- Fixed Ctrl+T mode toggle (`agent.state.tools`) and `peek_main` tool-call display for the current pi API
- [issue] However,if enables mouse scroll , terminal modes like cursor text select ,and copy hotkeys  wont work ,see issues#7

# Changelog

`CHANGELOG.md` documents the feature (prompt / context / tool harness / UI polish). Typecheck: `npm run typecheck` (tsconfig added, dev workspace deps declared).
