### PR TITLE
fix: keep side chat on side-chat requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed Ctrl+T edit-mode toggling on current pi versions. Thanks to [@johnrichardrinehart](https://github.com/johnrichardrinehart) for PR #2.
 - Added configurable fullscreen toggling for the side-chat overlay. Thanks to [@johnrichardrinehart](https://github.com/johnrichardrinehart) for PR #3.
+- Fixed side-chat forks opened during main-agent tool calls by treating copied context as reference-only and sanitizing unfinished tool exchanges. Thanks to [@yceachan](https://github.com/yceachan) for issue #5 and the PR #8 design.
 
 ## [0.1.4] - 2026-04-15
 

--- a/fork-surgery.ts
+++ b/fork-surgery.ts
@@ -1,0 +1,69 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+
+export const FORKED_MID_EXECUTION_TEXT =
+  "[forked mid-execution — the main lane was still running this tool call when the side chat opened]";
+
+export function forkSurgery(messages: AgentMessage[], forkTimestamp = Date.now()): AgentMessage[] {
+  let end = messages.length;
+  while (end > 0 && messages[end - 1].role === "user") end--;
+
+  let start = end;
+  while (start > 0) {
+    const message = messages[start - 1];
+    if (message.role === "toolResult") {
+      start--;
+      continue;
+    }
+    if (message.role === "assistant" && hasToolCalls(message)) {
+      start--;
+      continue;
+    }
+    break;
+  }
+
+  const carryStart = start > 0 && messages[start - 1].role === "user" ? start - 1 : start;
+  const region = messages.slice(start, end);
+  const cut = end < messages.length || carryStart < start;
+  if (!cut && region.length === 0) return messages;
+
+  const callNames = new Map<string, string>();
+  const resultIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      for (const block of message.content) {
+        if (block.type === "toolCall") callNames.set(block.id, block.name);
+      }
+    } else if (message.role === "toolResult") {
+      resultIds.add(message.toolCallId);
+    }
+  }
+
+  const kept = region.filter((message) => message.role !== "toolResult" || callNames.has(message.toolCallId));
+  const synthesized: ToolResultMessage[] = [];
+  const regionCallIds = new Set<string>();
+  for (const message of region) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.content) {
+      if (block.type === "toolCall") regionCallIds.add(block.id);
+    }
+  }
+  for (const id of regionCallIds) {
+    if (resultIds.has(id)) continue;
+    synthesized.push({
+      role: "toolResult",
+      toolCallId: id,
+      toolName: callNames.get(id) ?? "unknown",
+      content: [{ type: "text", text: FORKED_MID_EXECUTION_TEXT }],
+      isError: false,
+      timestamp: forkTimestamp,
+    });
+  }
+
+  if (!cut && kept.length === region.length && synthesized.length === 0) return messages;
+  return [...messages.slice(0, carryStart), ...kept, ...synthesized];
+}
+
+function hasToolCalls(message: AgentMessage): boolean {
+  return message.role === "assistant" && message.content.some((block) => block.type === "toolCall");
+}

--- a/index.ts
+++ b/index.ts
@@ -92,6 +92,7 @@ export default function sideChatExtension(pi: ExtensionAPI) {
     const sessionContext = buildSessionContext(ctx.sessionManager.getEntries(), ctx.sessionManager.getLeafId());
     const forkContext: ForkContext = {
       messages: clear ? [] : (lastMessages ?? sessionContext.messages),
+      restored: !clear && lastMessages !== null,
       model: ctx.model,
       systemPrompt: ctx.getSystemPrompt(),
       thinkingLevel: pi.getThinkingLevel(),

--- a/side-chat-messages.ts
+++ b/side-chat-messages.ts
@@ -2,6 +2,17 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { Key, matchesKey, wrapTextWithAnsi, type Component } from "@mariozechner/pi-tui";
 import type { Theme } from "@mariozechner/pi-coding-agent";
 
+const FRAMING_MESSAGE = Symbol("side-chat-framing");
+
+export function markFramingMessage(message: AgentMessage): AgentMessage {
+  Object.defineProperty(message, FRAMING_MESSAGE, { value: true });
+  return message;
+}
+
+export function isFramingMessage(message: AgentMessage): boolean {
+  return (message as AgentMessage & { [FRAMING_MESSAGE]?: boolean })[FRAMING_MESSAGE] === true;
+}
+
 export class SideChatMessages implements Component {
   private messages: AgentMessage[] = [];
   private streamingContent = "";
@@ -40,6 +51,7 @@ export class SideChatMessages implements Component {
     const lines: string[] = [];
 
     for (const msg of this.messages) {
+      if (isFramingMessage(msg)) continue;
       const messageLines = this.renderMessage(msg, width);
       if (messageLines.length) {
         lines.push(...messageLines, "");

--- a/side-chat-overlay.ts
+++ b/side-chat-overlay.ts
@@ -13,12 +13,14 @@ import {
 import { Type } from "@sinclair/typebox";
 import { Editor, Key, matchesKey, truncateToWidth, visibleWidth, type Component, type Focusable, type TUI } from "@mariozechner/pi-tui";
 import type { FileActivityTracker } from "./file-activity-tracker.ts";
+import { forkSurgery } from "./fork-surgery.ts";
 import { getMaxMessageLines, type DisplayMode } from "./side-chat-layout.ts";
-import { SideChatMessages } from "./side-chat-messages.ts";
+import { isFramingMessage, markFramingMessage, SideChatMessages } from "./side-chat-messages.ts";
 import { wrapToolsWithOverlapDetection } from "./tool-wrapper.ts";
 
 export interface ForkContext {
   messages: AgentMessage[];
+  restored?: boolean;
   model: Model<any>;
   systemPrompt: string;
   thinkingLevel: ThinkingLevel;
@@ -50,6 +52,8 @@ You're in a SIDE CHAT parallel to the main agent. Main is working independently 
 Use \`peek_main\` to see main's activity when user asks about progress or you need context.
 Use \`peek_main({ since_fork: true })\` for activity since side chat opened.
 
+The copied main context is reference only. Do not continue its pending user request, tool call, reasoning, edits, or unfinished answer. Answer the latest user message in this side chat.
+
 Be concise - this is for quick questions. If user wants something main is doing, suggest waiting.`;
 
 const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -74,7 +78,16 @@ export class SideChatOverlay implements Component, Focusable {
 
   constructor(private options: SideChatOverlayOptions) {
     const { tui, theme, forkContext, modelRegistry, sessionManager } = options;
-    const forkedMessages = JSON.parse(JSON.stringify(forkContext.messages)) as AgentMessage[];
+    const forkedMessages = forkContext.restored
+      ? JSON.parse(JSON.stringify(forkContext.messages)) as AgentMessage[]
+      : forkSurgery(JSON.parse(JSON.stringify(forkContext.messages)) as AgentMessage[]);
+    const framingMessage = forkContext.restored
+      ? undefined
+      : markFramingMessage({
+        role: "user",
+        content: "The preceding messages are copied main-session context for reference only. Answer the latest side-chat user message; do not resume the main lane's pending work.",
+        timestamp: Date.now(),
+      });
     const initialTools = createReadOnlyTools(forkContext.cwd);
 
     this.forkLeafId = sessionManager.getLeafId();
@@ -86,7 +99,7 @@ export class SideChatOverlay implements Component, Focusable {
         model: forkContext.model,
         thinkingLevel: forkContext.thinkingLevel,
         tools: [...initialTools, ...forkContext.extensionTools, this.peekMainTool],
-        messages: forkedMessages,
+        messages: framingMessage ? [...forkedMessages, framingMessage] : forkedMessages,
       },
       convertToLlm,
       getApiKey: async (provider) => {
@@ -351,7 +364,7 @@ export class SideChatOverlay implements Component, Focusable {
     if (this.disposed) return;
     this.disposed = true;
     this.stopSpinner();
-    const messages = [...this.agent.state.messages];
+    const messages = this.agent.state.messages.filter((message) => !isFramingMessage(message));
     this.agent.abort();
     this.options.onClose(action, messages);
   }

--- a/test/fork-surgery.test.ts
+++ b/test/fork-surgery.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { forkSurgery, FORKED_MID_EXECUTION_TEXT } from "../fork-surgery.ts";
+
+const assistantToolCall = (id: string): AgentMessage => ({
+  role: "assistant",
+  content: [{ type: "toolCall", id, name: "read", arguments: { path: "file.ts" } }],
+  api: "openai-completions",
+  provider: "test",
+  model: "test",
+  usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+  stopReason: "toolUse",
+  timestamp: 1,
+} as AgentMessage);
+
+const user = (content: string): AgentMessage => ({ role: "user", content, timestamp: 1 } as AgentMessage);
+
+test("sanitizes a fork opened during a tool call", () => {
+  const result = forkSurgery([
+    user("main task"),
+    assistantToolCall("call-1"),
+  ], 42);
+
+  assert.equal(result.length, 2);
+  assert.equal(result[0]?.role, "assistant");
+  assert.equal(result[1]?.role, "toolResult");
+  assert.equal(result[1]?.toolCallId, "call-1");
+  assert.equal(result[1]?.content[0]?.type, "text");
+  assert.equal(result[1]?.content[0]?.type === "text" ? result[1].content[0].text : "", FORKED_MID_EXECUTION_TEXT);
+});
+
+test("cuts trailing main user messages and keeps answered history unchanged", () => {
+  const answered = { role: "assistant", content: [{ type: "text", text: "done" }], timestamp: 2 } as AgentMessage;
+  const result = forkSurgery([
+    user("older task"),
+    answered,
+    user("pending main question"),
+  ]);
+
+  assert.deepEqual(result, [user("older task"), answered]);
+});

--- a/test/side-chat-messages.test.ts
+++ b/test/side-chat-messages.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SideChatMessages } from "../side-chat-messages.ts";
+import { markFramingMessage, SideChatMessages } from "../side-chat-messages.ts";
 
 const theme = { fg: (_color: string, text: string) => text };
 
@@ -24,4 +24,16 @@ test("viewport resize clamps scroll offset without resetting it", () => {
   assert.equal(state.scrollOffset, 5);
   messages.setMaxVisibleLines(5);
   assert.equal(state.scrollOffset, 5);
+});
+
+test("framing message is sent to the agent but not rendered as a chat bubble", () => {
+  const messages = new SideChatMessages(theme as never, 10);
+  messages.setMessages([
+    markFramingMessage({ role: "user", content: "reference only", timestamp: 1 }),
+    { role: "user", content: "latest side question", timestamp: 2 },
+  ]);
+
+  const rendered = messages.render(80).join("\n");
+  assert.doesNotMatch(rendered, /reference only/);
+  assert.match(rendered, /latest side question/);
 });


### PR DESCRIPTION
Closes #5.

This is the clean replacement for the narrow issue #5 behavior from PR #8. It keeps the side chat from treating fresh main-session context as its own active task when the fork happens during a main-agent tool call or pending request.

It adds tail-only fork snapshot surgery, hidden reference-only side-chat framing, and restored-session handling so close/reopen history is not re-sanitized. It intentionally leaves out the unrelated PR #8 UI, export, mouse, prompt-pack, package, lockfile, and license changes.

Thanks to [@yceachan](https://github.com/yceachan) for issue #5 and the PR #8 design.

Validation:
- `npm test` passed 18/18.
- `git diff --check` passed.
- Fresh review found no issues.
