### PR TITLE
fix: avoid fullscreen shortcut conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the default fullscreen shortcut to `Alt+Shift+M` so it no longer conflicts with pi-interactive-shell's focus shortcut.
+
 ## [0.2.0] - 2026-08-23
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Press `Esc` to close it. Reopen with `Alt+/` to continue where you left off.
 
 **Toggle mode** — `Ctrl+T` switches between read-only and edit mode.
 
-**Toggle fullscreen** — `Alt+Shift+F` expands the open side chat to the terminal bounds. Press it again to restore the compact overlay. The conversation, draft, focus, and scroll position remain in place.
+**Toggle fullscreen** — `Alt+Shift+M` expands the open side chat to the terminal bounds. Press it again to restore the compact overlay. The conversation, draft, focus, and scroll position remain in place.
 
 **Start fresh** — `Alt+R` re-forks from the latest main context. `Alt+N` starts a blank conversation.
 
@@ -60,7 +60,7 @@ What changed since I opened this side chat?
 | Key | Action |
 |-----|--------|
 | `Alt+/` | Open side chat / toggle focus |
-| `Alt+Shift+F` | Toggle compact / fullscreen view |
+| `Alt+Shift+M` | Toggle compact / fullscreen view |
 | `Enter` | Send message |
 | `Esc` | Interrupt streaming, or close when idle |
 | `Alt+R` | Re-fork from latest main context |
@@ -91,7 +91,7 @@ Create a `config.json` next to the extension to change the shortcut:
 ```json
 {
   "shortcut": "alt+/",
-  "fullscreenShortcut": "alt+shift+f"
+  "fullscreenShortcut": "alt+shift+m"
 }
 ```
 

--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,7 @@ function getExtensionAgentTools(): AgentTool[] {
 }
 
 const DEFAULT_SHORTCUT = "alt+/";
-const DEFAULT_FULLSCREEN_SHORTCUT = "alt+shift+f";
+const DEFAULT_FULLSCREEN_SHORTCUT = "alt+shift+m";
 const OVERLAY_BLOCKED_ERROR = "PI_SIDE_CHAT_OVERLAY_BLOCKED";
 
 function loadConfig(): { shortcut: string; fullscreenShortcut: string } {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,7 +23,7 @@ test("extension updates the live overlay options object in place", async () => {
   sideChatExtension(pi as never);
 
   const command = commands.get("side");
-  const fullscreenShortcut = shortcuts.get("alt+shift+f");
+  const fullscreenShortcut = shortcuts.get("alt+shift+m");
   assert.ok(command);
   assert.ok(fullscreenShortcut);
 
@@ -84,7 +84,7 @@ test("extension updates the live overlay options object in place", async () => {
           nonCapturing: true,
         });
 
-        overlay.handleInput("\x1b[70;4u");
+        overlay.handleInput("\x1b[77;4u");
         assert.equal(options.overlayOptions, originalOptions);
         assert.deepEqual(originalOptions, {
           width: "100%",

--- a/test/side-chat-fullscreen.test.ts
+++ b/test/side-chat-fullscreen.test.ts
@@ -40,7 +40,7 @@ function createOverlay(rows = 40) {
     modelRegistry: { getApiKeyForProvider: async () => "test" },
     sessionManager: { getLeafId: () => null, getEntries: () => [] },
     shortcut: "alt+/",
-    fullscreenShortcut: "alt+shift+f",
+    fullscreenShortcut: "alt+shift+m",
     onDisplayModeChange: (mode: DisplayMode) => { displayChanges.push(mode); },
     onOverlapWarning: async () => true,
     onUnfocus: () => {},
@@ -93,7 +93,7 @@ test("fullscreen toggle preserves live overlay state and consumes its key", () =
   privateState.isStreaming = true;
   const cursor = privateState.editor.getCursor();
 
-  state.overlay.handleInput("\x1b[70;4u");
+  state.overlay.handleInput("\x1b[77;4u");
 
   assert.deepEqual(state.displayChanges, ["fullscreen"]);
   assert.equal(internals(state.overlay).agent, originalAgent);
@@ -106,10 +106,10 @@ test("fullscreen toggle preserves live overlay state and consumes its key", () =
 
   const fullscreenLines = state.overlay.render(120);
   assert.equal(fullscreenLines.length, 40);
-  assert.match(fullscreenLines.join("\n"), /Alt\+Shift\+F restore/);
+  assert.match(fullscreenLines.join("\n"), /Alt\+Shift\+M restore/);
   assert.ok(fullscreenLines.every((line) => visibleWidth(line) <= 120));
 
-  state.overlay.handleInput("\x1b[70;4u");
+  state.overlay.handleInput("\x1b[77;4u");
 
   assert.deepEqual(state.displayChanges, ["fullscreen", "compact"]);
   assert.equal(privateState.editor.getText(), "draft text");
@@ -120,7 +120,7 @@ test("fullscreen toggle preserves live overlay state and consumes its key", () =
 
   const compactLines = state.overlay.render(120);
   assert.equal(compactLines.length, 14);
-  assert.match(compactLines.join("\n"), /Alt\+Shift\+F fullscreen/);
+  assert.match(compactLines.join("\n"), /Alt\+Shift\+M fullscreen/);
   assert.ok(compactLines.every((line) => visibleWidth(line) <= 120));
 });
 
@@ -128,7 +128,7 @@ test("resize recalculates both display modes without exceeding width", () => {
   const state = createOverlay(24);
 
   assert.equal(state.overlay.render(80).length, 13);
-  state.overlay.handleInput("\x1b[70;4u");
+  state.overlay.handleInput("\x1b[77;4u");
   assert.equal(state.overlay.render(80).length, 24);
 
   state.tui.terminal.rows = 50;
@@ -141,7 +141,7 @@ test("fullscreen stays within terminal rows with a multiline editor", () => {
   const privateState = internals(state.overlay);
   privateState.editor.setText("line one\nline two\nline three\nline four");
 
-  state.overlay.handleInput("\x1b[70;4u");
+  state.overlay.handleInput("\x1b[77;4u");
 
   assert.equal(state.overlay.render(80).length, 10);
 });
@@ -149,7 +149,7 @@ test("fullscreen stays within terminal rows with a multiline editor", () => {
 test("fullscreen stays within terminals shorter than its fixed chrome", () => {
   const state = createOverlay(5);
 
-  state.overlay.handleInput("\x1b[70;4u");
+  state.overlay.handleInput("\x1b[77;4u");
 
   assert.equal(state.overlay.render(80).length, 5);
 });

--- a/test/side-chat-overlay.test.ts
+++ b/test/side-chat-overlay.test.ts
@@ -54,7 +54,7 @@ function createOverlay() {
       getEntries: () => [],
     },
     shortcut: "alt+/",
-    fullscreenShortcut: "alt+shift+f",
+    fullscreenShortcut: "alt+shift+m",
     onDisplayModeChange: () => {},
     onOverlapWarning: async () => {
       overlapWarnings++;


### PR DESCRIPTION
## Summary
- change the default side-chat fullscreen shortcut from Alt+Shift+F to Alt+Shift+M
- update README, changelog, and shortcut tests

## Test
- npm test (after temporary npm install --no-save --package-lock=false; node_modules removed afterward)
- git diff --check