### PR TITLE
feat: persist shortcut config in the agent directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Configuration can now be read from `pi-side-chat.json` in the Pi agent directory, so custom shortcuts survive extension updates. The module-local `config.json` remains as a fallback.
+
 ### Changed
 
 - Changed the default fullscreen shortcut to `Alt+Shift+M` so it no longer conflicts with pi-interactive-shell's focus shortcut.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Available to the side agent only.
 
 ## Configuration
 
-Create a `config.json` next to the extension to change the shortcut:
+Create `pi-side-chat.json` in your Pi agent directory (`~/.pi/agent/pi-side-chat.json`, or `$PI_CODING_AGENT_DIR/pi-side-chat.json` when set) to change the shortcuts:
 
 ```json
 {
@@ -94,6 +94,8 @@ Create a `config.json` next to the extension to change the shortcut:
   "fullscreenShortcut": "alt+shift+m"
 }
 ```
+
+A `config.json` next to the extension module also works as a fallback, but it is deleted whenever the extension is updated or reinstalled.
 
 ## How It Works
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage, AgentTool } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@mariozechner/pi-coding-agent";
 import type { OverlayHandle } from "@mariozechner/pi-tui";
-import { buildSessionContext, ExtensionRunner } from "@mariozechner/pi-coding-agent";
+import { buildSessionContext, ExtensionRunner, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -38,23 +38,33 @@ const DEFAULT_FULLSCREEN_SHORTCUT = "alt+shift+m";
 const OVERLAY_BLOCKED_ERROR = "PI_SIDE_CHAT_OVERLAY_BLOCKED";
 
 function loadConfig(): { shortcut: string; fullscreenShortcut: string } {
-  const configPath = join(dirname(fileURLToPath(import.meta.url)), "config.json");
-  try {
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
-    const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
-      ? config.fullscreenShortcut.trim()
-      : "";
-    return {
-      shortcut: shortcut || DEFAULT_SHORTCUT,
-      fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
-    };
-  } catch {
-    return {
-      shortcut: DEFAULT_SHORTCUT,
-      fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
-    };
+  // The module-local config.json disappears on every extension update/reinstall,
+  // so the agent-dir location is preferred and the module-local file is the fallback.
+  const paths = [
+    join(getAgentDir(), "pi-side-chat.json"),
+    join(dirname(fileURLToPath(import.meta.url)), "config.json"),
+  ];
+  for (const configPath of paths) {
+    try {
+      const config = JSON.parse(readFileSync(configPath, "utf-8"));
+      const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
+      const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
+        ? config.fullscreenShortcut.trim()
+        : "";
+      if (shortcut || fullscreenShortcut) {
+        return {
+          shortcut: shortcut || DEFAULT_SHORTCUT,
+          fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
+        };
+      }
+    } catch {
+      // Missing, unreadable, or invalid JSON: try the next location.
+    }
   }
+  return {
+    shortcut: DEFAULT_SHORTCUT,
+    fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
+  };
 }
 
 export default function sideChatExtension(pi: ExtensionAPI) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import test from "node:test";
+import { join } from "node:path";
 import type { OverlayOptions } from "@mariozechner/pi-tui";
 import sideChatExtension from "../index.ts";
 
@@ -114,4 +117,38 @@ test("extension updates the live overlay options object in place", async () => {
   };
 
   await command.handler("", context);
+});
+
+test("loads shortcuts from the agent dir config before the module-local config", () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-side-chat-test-"));
+  writeFileSync(
+    join(agentDir, "pi-side-chat.json"),
+    JSON.stringify({ shortcut: "ctrl+\\", fullscreenShortcut: "ctrl+space" }),
+  );
+  const previous = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const shortcuts = new Map<string, unknown>();
+    const pi = {
+      on: () => {},
+      getThinkingLevel: () => "off",
+      registerCommand: () => {},
+      registerShortcut: (name: string, definition: unknown) => {
+        shortcuts.set(name, definition);
+      },
+    };
+
+    sideChatExtension(pi as never);
+
+    assert.ok(shortcuts.has("ctrl+\\"));
+    assert.ok(shortcuts.has("ctrl+space"));
+    assert.equal(shortcuts.has("alt+/"), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previous;
+    }
+    rmSync(agentDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
tldr;
- installed this extension through pi (npm) and wanted to change my `config.json`
- it has to be stored in `~/.pi/agent/npm/node_modules/pi-side-chat/` which will be overwritten on next `pi update`
- should instead be stoed in pi config (default `~/.pi`) where it can be tracked in dotfiles managers

### summary

`config.json` currently sits next to the extension module, which for npm installs means it lives inside `node_modules`, so every `pi update` or reinstall wipes custom shortcuts. found out the hard way.

`loadConfig` now tries `<agent dir>/pi-side-chat.json` first (via the host's `getAgentDir()`, so `PI_CODING_AGENT_DIR` and rebranded installs work), then falls back to the module-local `config.json` like before. first file that parses with at least one key set wins; empty or invalid files get skipped. nothing changes if you have neither.

added a test for the agent-dir lookup and updated the `README` + changelog. 19/19 tests pass.
