### PR TITLE
feat: keep shortcut configuration in the agent directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Configuration can now be read from `pi-side-chat.json` in the Pi agent directory, so custom shortcuts survive extension updates. The module-local `config.json` remains as a fallback.
+
 ### Changed
 
 - Changed the default fullscreen shortcut to `Alt+Shift+M` so it no longer conflicts with pi-interactive-shell's focus shortcut.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Configuration can now be read from `pi-side-chat.json` in the Pi agent directory, so custom shortcuts survive extension updates. The module-local `config.json` remains as a fallback.
+- Configuration can now be read from `pi-side-chat.json` in the Pi agent directory, so custom shortcuts survive extension updates. Thanks to [@Jish2](https://github.com/Jish2) for PR #11.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Create `pi-side-chat.json` in your Pi agent directory (`~/.pi/agent/pi-side-chat
 }
 ```
 
-A `config.json` next to the extension module also works as a fallback, but it is deleted whenever the extension is updated or reinstalled.
+The extension reads only this agent-directory file. If you previously used a `config.json` next to the extension module, move its contents here and rename it to `pi-side-chat.json`. `PI_CODING_AGENT_DIR` determines the agent directory when set.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Available to the side agent only.
 
 ## Configuration
 
-Create a `config.json` next to the extension to change the shortcut:
+Create `pi-side-chat.json` in your Pi agent directory (`~/.pi/agent/pi-side-chat.json`, or `$PI_CODING_AGENT_DIR/pi-side-chat.json` when set) to change the shortcuts:
 
 ```json
 {
@@ -94,6 +94,8 @@ Create a `config.json` next to the extension to change the shortcut:
   "fullscreenShortcut": "alt+shift+m"
 }
 ```
+
+A `config.json` next to the extension module also works as a fallback, but it is deleted whenever the extension is updated or reinstalled.
 
 ## How It Works
 

--- a/index.ts
+++ b/index.ts
@@ -3,8 +3,7 @@ import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@marioz
 import type { OverlayHandle } from "@mariozechner/pi-tui";
 import { buildSessionContext, ExtensionRunner, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { FileActivityTracker } from "./file-activity-tracker.ts";
 import { getOverlayOptions } from "./side-chat-layout.ts";
 import { SideChatOverlay, type ForkContext } from "./side-chat-overlay.ts";
@@ -38,28 +37,19 @@ const DEFAULT_FULLSCREEN_SHORTCUT = "alt+shift+m";
 const OVERLAY_BLOCKED_ERROR = "PI_SIDE_CHAT_OVERLAY_BLOCKED";
 
 function loadConfig(): { shortcut: string; fullscreenShortcut: string } {
-  // The module-local config.json disappears on every extension update/reinstall,
-  // so the agent-dir location is preferred and the module-local file is the fallback.
-  const paths = [
-    join(getAgentDir(), "pi-side-chat.json"),
-    join(dirname(fileURLToPath(import.meta.url)), "config.json"),
-  ];
-  for (const configPath of paths) {
-    try {
-      const config = JSON.parse(readFileSync(configPath, "utf-8"));
-      const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
-      const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
-        ? config.fullscreenShortcut.trim()
-        : "";
-      if (shortcut || fullscreenShortcut) {
-        return {
-          shortcut: shortcut || DEFAULT_SHORTCUT,
-          fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
-        };
-      }
-    } catch {
-      // Missing, unreadable, or invalid JSON: try the next location.
-    }
+  const configPath = join(getAgentDir(), "pi-side-chat.json");
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
+    const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
+      ? config.fullscreenShortcut.trim()
+      : "";
+    return {
+      shortcut: shortcut || DEFAULT_SHORTCUT,
+      fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
+    };
+  } catch {
+    // Missing, unreadable, or invalid JSON: use defaults.
   }
   return {
     shortcut: DEFAULT_SHORTCUT,

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage, AgentTool } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@mariozechner/pi-coding-agent";
 import type { OverlayHandle } from "@mariozechner/pi-tui";
-import { buildSessionContext, ExtensionRunner } from "@mariozechner/pi-coding-agent";
+import { buildSessionContext, ExtensionRunner, getAgentDir } from "@mariozechner/pi-coding-agent";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -38,23 +38,33 @@ const DEFAULT_FULLSCREEN_SHORTCUT = "alt+shift+m";
 const OVERLAY_BLOCKED_ERROR = "PI_SIDE_CHAT_OVERLAY_BLOCKED";
 
 function loadConfig(): { shortcut: string; fullscreenShortcut: string } {
-  const configPath = join(dirname(fileURLToPath(import.meta.url)), "config.json");
-  try {
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
-    const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
-      ? config.fullscreenShortcut.trim()
-      : "";
-    return {
-      shortcut: shortcut || DEFAULT_SHORTCUT,
-      fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
-    };
-  } catch {
-    return {
-      shortcut: DEFAULT_SHORTCUT,
-      fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
-    };
+  // The module-local config.json disappears on every extension update/reinstall,
+  // so the agent-dir location is preferred and the module-local file is the fallback.
+  const paths = [
+    join(getAgentDir(), "pi-side-chat.json"),
+    join(dirname(fileURLToPath(import.meta.url)), "config.json"),
+  ];
+  for (const configPath of paths) {
+    try {
+      const config = JSON.parse(readFileSync(configPath, "utf-8"));
+      const shortcut = typeof config.shortcut === "string" ? config.shortcut.trim() : "";
+      const fullscreenShortcut = typeof config.fullscreenShortcut === "string"
+        ? config.fullscreenShortcut.trim()
+        : "";
+      if (shortcut || fullscreenShortcut) {
+        return {
+          shortcut: shortcut || DEFAULT_SHORTCUT,
+          fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
+        };
+      }
+    } catch {
+      // Missing, unreadable, or invalid JSON: try the next location.
+    }
   }
+  return {
+    shortcut: DEFAULT_SHORTCUT,
+    fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
+  };
 }
 
 export default function sideChatExtension(pi: ExtensionAPI) {

--- a/index.ts
+++ b/index.ts
@@ -49,12 +49,11 @@ function loadConfig(): { shortcut: string; fullscreenShortcut: string } {
       fullscreenShortcut: fullscreenShortcut || DEFAULT_FULLSCREEN_SHORTCUT,
     };
   } catch {
-    // Missing, unreadable, or invalid JSON: use defaults.
+    return {
+      shortcut: DEFAULT_SHORTCUT,
+      fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
+    };
   }
-  return {
-    shortcut: DEFAULT_SHORTCUT,
-    fullscreenShortcut: DEFAULT_FULLSCREEN_SHORTCUT,
-  };
 }
 
 export default function sideChatExtension(pi: ExtensionAPI) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,6 +6,22 @@ import { join } from "node:path";
 import type { OverlayOptions } from "@mariozechner/pi-tui";
 import sideChatExtension from "../index.ts";
 
+const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+const testAgentDir = mkdtempSync(join(tmpdir(), "pi-side-chat-test-"));
+
+test.before(() => {
+  process.env.PI_CODING_AGENT_DIR = testAgentDir;
+});
+
+test.after(() => {
+  if (previousAgentDir === undefined) {
+    delete process.env.PI_CODING_AGENT_DIR;
+  } else {
+    process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+  rmSync(testAgentDir, { recursive: true, force: true });
+});
+
 test("extension updates the live overlay options object in place", async () => {
   const commands = new Map<string, { handler: (args: string, context: unknown) => unknown }>();
   const shortcuts = new Map<string, { handler: (context: unknown) => unknown }>();
@@ -26,8 +42,10 @@ test("extension updates the live overlay options object in place", async () => {
   sideChatExtension(pi as never);
 
   const command = commands.get("side");
+  const shortcut = shortcuts.get("alt+/");
   const fullscreenShortcut = shortcuts.get("alt+shift+m");
   assert.ok(command);
+  assert.ok(shortcut);
   assert.ok(fullscreenShortcut);
 
   const model = {
@@ -119,36 +137,26 @@ test("extension updates the live overlay options object in place", async () => {
   await command.handler("", context);
 });
 
-test("loads shortcuts from the agent dir config before the module-local config", () => {
-  const agentDir = mkdtempSync(join(tmpdir(), "pi-side-chat-test-"));
+test("loads custom shortcuts from the agent dir config", () => {
   writeFileSync(
-    join(agentDir, "pi-side-chat.json"),
+    join(testAgentDir, "pi-side-chat.json"),
     JSON.stringify({ shortcut: "ctrl+\\", fullscreenShortcut: "ctrl+space" }),
   );
-  const previous = process.env.PI_CODING_AGENT_DIR;
-  process.env.PI_CODING_AGENT_DIR = agentDir;
-  try {
-    const shortcuts = new Map<string, unknown>();
-    const pi = {
-      on: () => {},
-      getThinkingLevel: () => "off",
-      registerCommand: () => {},
-      registerShortcut: (name: string, definition: unknown) => {
-        shortcuts.set(name, definition);
-      },
-    };
 
-    sideChatExtension(pi as never);
+  const shortcuts = new Map<string, unknown>();
+  const pi = {
+    on: () => {},
+    getThinkingLevel: () => "off",
+    registerCommand: () => {},
+    registerShortcut: (name: string, definition: unknown) => {
+      shortcuts.set(name, definition);
+    },
+  };
 
-    assert.ok(shortcuts.has("ctrl+\\"));
-    assert.ok(shortcuts.has("ctrl+space"));
-    assert.equal(shortcuts.has("alt+/"), false);
-  } finally {
-    if (previous === undefined) {
-      delete process.env.PI_CODING_AGENT_DIR;
-    } else {
-      process.env.PI_CODING_AGENT_DIR = previous;
-    }
-    rmSync(agentDir, { recursive: true, force: true });
-  }
+  sideChatExtension(pi as never);
+
+  assert.ok(shortcuts.has("ctrl+\\"));
+  assert.ok(shortcuts.has("ctrl+space"));
+  assert.equal(shortcuts.has("alt+/"), false);
+  assert.equal(shortcuts.has("alt+shift+m"), false);
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import test from "node:test";
+import { join } from "node:path";
 import type { OverlayOptions } from "@mariozechner/pi-tui";
 import sideChatExtension from "../index.ts";
 
@@ -114,4 +117,38 @@ test("extension updates the live overlay options object in place", async () => {
   };
 
   await command.handler("", context);
+});
+
+test("loads shortcuts from the agent dir config before the module-local config", () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-side-chat-test-"));
+  writeFileSync(
+    join(agentDir, "pi-side-chat.json"),
+    JSON.stringify({ shortcut: "ctrl+\\", fullscreenShortcut: "ctrl+space" }),
+  );
+  const previous = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const shortcuts = new Map<string, unknown>();
+    const pi = {
+      on: () => {},
+      getThinkingLevel: () => "off",
+      registerCommand: () => {},
+      registerShortcut: (name: string, definition: unknown) => {
+        shortcuts.set(name, definition);
+      },
+    };
+
+    sideChatExtension(pi as never);
+
+    assert.ok(shortcuts.has("ctrl+\\"));
+    assert.ok(shortcuts.has("ctrl+space"));
+    assert.equal(shortcuts.has("alt+/"), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previous;
+    }
+    rmSync(agentDir, { recursive: true, force: true });
+  }
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,10 +42,9 @@ test("extension updates the live overlay options object in place", async () => {
   sideChatExtension(pi as never);
 
   const command = commands.get("side");
-  const shortcut = shortcuts.get("alt+/");
   const fullscreenShortcut = shortcuts.get("alt+shift+m");
   assert.ok(command);
-  assert.ok(shortcut);
+  assert.ok(shortcuts.get("alt+/"));
   assert.ok(fullscreenShortcut);
 
   const model = {
@@ -146,7 +145,6 @@ test("loads custom shortcuts from the agent dir config", () => {
   const shortcuts = new Map<string, unknown>();
   const pi = {
     on: () => {},
-    getThinkingLevel: () => "off",
     registerCommand: () => {},
     registerShortcut: (name: string, definition: unknown) => {
       shortcuts.set(name, definition);


### PR DESCRIPTION
Preserves the configuration fix from #11 by [@Jish2](https://github.com/Jish2), including the original contributor commit and changelog credit.

Shortcut settings now live in `~/.pi/agent/pi-side-chat.json` (or the directory selected by `PI_CODING_AGENT_DIR`) so package updates do not overwrite them. This is a hard cutover: move the old module-local `config.json` to the new path. There is no legacy fallback.

Also isolates the existing shortcut tests from personal configuration and verifies that custom bindings replace the defaults.

Validation: all 19 tests pass, including the previously failing custom-environment case in focused validation. Fresh read-only review found no issues. Diff hygiene is clean. No CI workflows are configured.

Replaces #11 with the reviewed maintainer changes. No release is included.